### PR TITLE
Allow to use v2.8, but not context and fromContext directives

### DIFF
--- a/.changeset/cruel-parrots-crash.md
+++ b/.changeset/cruel-parrots-crash.md
@@ -2,4 +2,4 @@
 '@theguild/federation-composition': minor
 ---
 
-Allow to use v2.8, but not @context and @fromContext directives
+Allow to use v2.8, but not `@context` and `@fromContext` directives

--- a/.changeset/cruel-parrots-crash.md
+++ b/.changeset/cruel-parrots-crash.md
@@ -1,0 +1,5 @@
+---
+'@theguild/federation-composition': minor
+---
+
+Allow to use v2.8, but not @context and @fromContext directives

--- a/__tests__/context.spec.ts
+++ b/__tests__/context.spec.ts
@@ -1,0 +1,144 @@
+import { parse, print } from 'graphql';
+import { describe, expect, test } from 'vitest';
+import { sortSDL } from '../src/graphql/sort-sdl.js';
+import {
+  assertCompositionFailure,
+  assertCompositionSuccess,
+  satisfiesVersionRange,
+  testVersions,
+} from './shared/testkit.js';
+
+expect.addSnapshotSerializer({
+  serialize: value => print(sortSDL(parse(value as string))),
+  test: value => typeof value === 'string' && value.includes('specs.apollo.dev'),
+});
+
+describe('@context and @fromContext', () => {
+  testVersions((api, version) => {
+    const composeServices = api.composeServices;
+
+    if (satisfiesVersionRange('< v2.8', version)) {
+      test('not available, raise na error', () => {
+        const result = composeServices([
+          {
+            name: 'foo',
+            typeDefs: parse(/* GraphQL */ `
+              extend schema
+                @link(url: "https://specs.apollo.dev/federation/${version}", import: ["@key", "@context", "@fromContext", "@shareable", "@external"])
+
+              type Currency @shareable {
+                 id: ID!
+                 isoCode: String!
+              }
+
+              type User @key(fields: "id") @context(name: "userContext") {
+                id: ID!
+                userCurrency: Currency! @external
+                lastTransaction: Transaction!
+              }
+
+              type Transaction @key(fields: "id") {
+                id: ID!
+                currency: Currency!
+                amount: Int!
+                amountInUserCurrency(
+                  currencyCode: String
+                      @fromContext(field: "$userContext { userCurrency { isoCode } }")
+                ): Int!
+              }
+            `),
+          },
+        ]);
+
+        assertCompositionFailure(result);
+
+        expect(result.errors).toContainEqual(
+          expect.objectContaining({
+            message: '[foo] Cannot import unknown element "@context".',
+            extensions: expect.objectContaining({
+              code: 'INVALID_LINK_DIRECTIVE_USAGE',
+            }),
+          }),
+        );
+
+        expect(result.errors).toContainEqual(
+          expect.objectContaining({
+            message: '[foo] Cannot import unknown element "@fromContext".',
+            extensions: expect.objectContaining({
+              code: 'INVALID_LINK_DIRECTIVE_USAGE',
+            }),
+          }),
+        );
+      });
+      return;
+    }
+
+    test(
+      api.library === 'guild'
+        ? `allow to use the version, but disallow to import @context and @fromContext`
+        : 'available, allow to use',
+      () => {
+        const result = composeServices([
+          {
+            name: 'foo',
+            typeDefs: parse(/* GraphQL */ `
+              extend schema
+                @link(url: "https://specs.apollo.dev/federation/${version}", import: ["@key", "@context", "@fromContext", "@shareable", "@external"])
+
+              type Currency @shareable {
+                 id: ID!
+                 isoCode: String!
+              }
+
+              type User @key(fields: "id") @context(name: "userContext") {
+                id: ID!
+                userCurrency: Currency!
+                lastTransaction: Transaction!
+              }
+
+              type Transaction @key(fields: "id") {
+                id: ID!
+                currency: Currency!
+                amount: Int!
+                amountInUserCurrency(
+                  currencyCode: String
+                      @fromContext(field: "$userContext { userCurrency { isoCode } }")
+                ): Int!
+              }
+
+              type Query {
+                user(id: ID!): User
+              }
+          `),
+          },
+        ]);
+
+        if (api.library === 'apollo') {
+          assertCompositionSuccess(result);
+          return;
+        }
+
+        // Our composition does not support override labels yet
+        assertCompositionFailure(result);
+
+        expect(result.errors).toContainEqual(
+          expect.objectContaining({
+            message: '[foo] @context directive is not yet supported.',
+            extensions: expect.objectContaining({
+              code: 'UNSUPPORTED_FEATURE',
+            }),
+          }),
+        );
+
+        expect(result.errors).toContainEqual(
+          expect.objectContaining({
+            message: '[foo] @fromContext directive is not yet supported.',
+            extensions: expect.objectContaining({
+              code: 'UNSUPPORTED_FEATURE',
+            }),
+          }),
+        );
+      },
+    );
+  });
+});

--- a/__tests__/shared/testkit.ts
+++ b/__tests__/shared/testkit.ts
@@ -25,7 +25,6 @@ const missingErrorCodes = [
   'IMPLEMENTED_BY_INACCESSIBLE',
   'INVALID_FEDERATION_SUPERGRAPH',
   'SHAREABLE_HAS_MISMATCHED_RUNTIME_TYPES',
-  'UNSUPPORTED_FEATURE',
   'UNSUPPORTED_LINKED_FEATURE',
 ];
 
@@ -95,7 +94,7 @@ export const versions = [
   'v2.5',
   'v2.6',
   'v2.7',
-  // 'v2.8',
+  'v2.8',
   'v2.9',
 ] as const;
 
@@ -108,7 +107,7 @@ export const federationVersionToJoinSpecVersion: Record<FederationVersion, strin
   'v2.5': 'v0.3',
   'v2.6': 'v0.3',
   'v2.7': 'v0.4',
-  // 'v2.8': 'v0.5',
+  'v2.8': 'v0.5',
   'v2.9': 'v0.5',
 };
 

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -97,7 +97,7 @@ export function composeServices(
     'v2.5': 'v0.3',
     'v2.6': 'v0.3',
     'v2.7': 'v0.4',
-    // 'v2.8': 'v0.5',
+    'v2.8': 'v0.5',
     'v2.9': 'v0.5',
   };
 

--- a/src/specifications/federation.ts
+++ b/src/specifications/federation.ts
@@ -287,6 +287,55 @@ const federationSpecFactory = {
       prefix,
       imports,
     ),
+  // TODO: Implement @context and @fromContext from v2.8
+  // TODO: Add @override(label:) from v2.7
+  'v2.8': (prefix: string, imports?: readonly LinkImport[]) =>
+    createTypeDefinitions(
+      /* GraphQL */ `
+        directive @policy(
+          policies: [[federation__Policy!]!]!
+        ) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+        directive @authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+        directive @requiresScopes(
+          scopes: [[federation__Scope!]!]!
+        ) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+        directive @composeDirective(name: String!) repeatable on SCHEMA
+        directive @extends on OBJECT | INTERFACE
+        directive @external on OBJECT | FIELD_DEFINITION
+        directive @key(
+          fields: FieldSet!
+          resolvable: Boolean = true
+        ) repeatable on OBJECT | INTERFACE
+        directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ENUM | ENUM_VALUE | SCALAR | INPUT_OBJECT | INPUT_FIELD_DEFINITION | ARGUMENT_DEFINITION
+        directive @interfaceObject on OBJECT
+        directive @override(from: String!) on FIELD_DEFINITION
+        directive @provides(fields: FieldSet!) on FIELD_DEFINITION
+        directive @requires(fields: FieldSet!) on FIELD_DEFINITION
+        directive @shareable repeatable on FIELD_DEFINITION | OBJECT
+        directive @tag(
+          name: String!
+        ) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+        directive @cost(
+          weight: Int!
+        ) on ARGUMENT_DEFINITION | ENUM | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT | SCALAR
+        directive @listSize(
+          assumedSize: Int
+          slicingArguments: [String!]
+          sizedFields: [String!]
+          requireOneSlicingArgument: Boolean = true
+        ) on FIELD_DEFINITION
+        directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+        directive @fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
+        scalar FieldSet
+        scalar federation__Policy
+        scalar federation__Scope
+        scalar federation__ContextFieldValue
+      `,
+      prefix,
+      imports,
+    ),
+  // TODO: Add @context and @fromContext from v2.8
+  // TODO: Add @override(label:) from v2.7
   'v2.9': (prefix: string, imports?: readonly LinkImport[]) =>
     createTypeDefinitions(
       /* GraphQL */ `
@@ -322,9 +371,12 @@ const federationSpecFactory = {
           sizedFields: [String!]
           requireOneSlicingArgument: Boolean = true
         ) on FIELD_DEFINITION
+        directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+        directive @fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
         scalar FieldSet
         scalar federation__Policy
         scalar federation__Scope
+        scalar federation__ContextFieldValue
       `,
       prefix,
       imports,

--- a/src/subgraph/validation/rules/elements/context.ts
+++ b/src/subgraph/validation/rules/elements/context.ts
@@ -1,0 +1,18 @@
+import { ASTVisitor, GraphQLError } from 'graphql';
+import type { SubgraphValidationContext } from '../../validation-context.js';
+
+export function ContextDirectiveRules(context: SubgraphValidationContext): ASTVisitor {
+  if (context.satisfiesVersionRange('>= v2.8')) {
+    if (context.federationImports.some(i => i.name === '@context' && i.kind === 'directive')) {
+      context.reportError(
+        new GraphQLError('@context directive is not yet supported.', {
+          extensions: {
+            code: 'UNSUPPORTED_FEATURE',
+          },
+        }),
+      );
+    }
+  }
+
+  return {};
+}

--- a/src/subgraph/validation/rules/elements/from-context.ts
+++ b/src/subgraph/validation/rules/elements/from-context.ts
@@ -1,0 +1,18 @@
+import { ASTVisitor, GraphQLError } from 'graphql';
+import type { SubgraphValidationContext } from '../../validation-context.js';
+
+export function FromContextDirectiveRules(context: SubgraphValidationContext): ASTVisitor {
+  if (context.satisfiesVersionRange('>= v2.8')) {
+    if (context.federationImports.some(i => i.name === '@fromContext' && i.kind === 'directive')) {
+      context.reportError(
+        new GraphQLError('@fromContext directive is not yet supported.', {
+          extensions: {
+            code: 'UNSUPPORTED_FEATURE',
+          },
+        }),
+      );
+    }
+  }
+
+  return {};
+}

--- a/src/subgraph/validation/validate-subgraph.ts
+++ b/src/subgraph/validation/validate-subgraph.ts
@@ -21,10 +21,12 @@ import { Link, LinkImport, parseLinkDirective } from '../../specifications/link.
 import { SubgraphStateBuilder } from '../state.js';
 import { AuthenticatedRule } from './rules/elements/authenticated.js';
 import { ComposeDirectiveRules } from './rules/elements/compose-directive.js';
+import { ContextDirectiveRules } from './rules/elements/context.js';
 import { CostRule } from './rules/elements/cost.js';
 import { ExtendsRules } from './rules/elements/extends.js';
 import { ExternalRules } from './rules/elements/external.js';
 import { FieldSetRules } from './rules/elements/field-set.js';
+import { FromContextDirectiveRules } from './rules/elements/from-context.js';
 import { InaccessibleRules } from './rules/elements/inaccessible.js';
 import { InterfaceObjectRules } from './rules/elements/interface-object.js';
 import { KeyRules } from './rules/elements/key.js';
@@ -148,6 +150,8 @@ export function validateSubgraph(
     CostRule,
     ListSizeRule,
     OverrideRules,
+    ContextDirectiveRules,
+    FromContextDirectiveRules,
     ExtendsRules,
     QueryRootTypeInaccessibleRule,
     KnownTypeNamesRule,

--- a/src/subgraph/validation/validation-context.ts
+++ b/src/subgraph/validation/validation-context.ts
@@ -267,6 +267,7 @@ export function createSubgraphValidationContext(
 
   return {
     stateBuilder,
+    federationImports: imports,
     isLinkSpecDirective(name: string) {
       return linkSpecDirectives.some(d => d.name.value === name);
     },


### PR DESCRIPTION
Related to #85, but does not close it