### PR TITLE
fix: directive with a non-null list arg of non-null enums

### DIFF
--- a/.changeset/short-pans-wash.md
+++ b/.changeset/short-pans-wash.md
@@ -1,0 +1,27 @@
+---
+"@theguild/federation-composition": patch
+---
+
+Fixes the issue where the composition gives errors in case of the following:
+
+```graphql
+extend schema
+    @link(
+        url: "https://specs.apollo.dev/federation/v2.7"
+        import: ["@key", "@composeDirective"]
+    )
+    @link(url: "https://myspecs.dev/myDirective/v1.0", import: ["@myDirective"])
+    @composeDirective(name: "@myDirective")
+
+directive @myDirective(myarg: [MyEnum!]!) on OBJECT # A directive with a non-nullable list argument of non-nullable enums
+enum MyEnum {
+    MY_ENUM_VALUE
+}
+type Query {
+    myRootField: MyObject
+}
+
+type MyObject @myDirective(myarg: []) {
+    myField: String
+}
+```

--- a/src/subgraph/validation/rules/provided-arguments-on-directives-rule.ts
+++ b/src/subgraph/validation/rules/provided-arguments-on-directives-rule.ts
@@ -53,10 +53,11 @@ export function ProvidedArgumentsOnDirectivesRule(
               if (printedType !== "Any" && printedType !== printedValue) {
                 // received empty list
                 if (printedValue === "[]") {
-                  // if the argument's type is a list, but the list item type is not non-null, then it's valid
+                  // An empty list can be a valid value for a list type
+                  // or a non-null list type
                   if (
-                    argDefinition.type.kind === Kind.LIST_TYPE &&
-                    argDefinition.type.type.kind !== Kind.NON_NULL_TYPE
+                    argDefinition.type.kind === Kind.LIST_TYPE ||
+                    argDefinition.type.kind === Kind.NON_NULL_TYPE && argDefinition.type.type.kind === Kind.LIST_TYPE
                   ) {
                     continue;
                   }


### PR DESCRIPTION
Ref GW-164

Fixes the issue where the composition gives errors in case of the following:

```graphql
extend schema
    @link(
        url: "https://specs.apollo.dev/federation/v2.7"
        import: ["@key", "@composeDirective"]
    )
    @link(url: "https://myspecs.dev/myDirective/v1.0", import: ["@myDirective"])
    @composeDirective(name: "@myDirective")

directive @myDirective(myarg: [MyEnum!]!) on OBJECT # A directive with a non-nullable list argument of non-nullable enums
enum MyEnum {
    MY_ENUM_VALUE
}
type Query {
    myRootField: MyObject
}

type MyObject @myDirective(myarg: []) {
    myField: String
}
```
