### PR TITLE
fix: don't throw for invalid tag directive usage

### DIFF
--- a/.changeset/chatty-readers-agree.md
+++ b/.changeset/chatty-readers-agree.md
@@ -1,0 +1,5 @@
+---
+"@theguild/federation-composition": patch
+---
+
+Do not throw an error when encountering invalid usage of `@tag` directive within subgraphs.

--- a/__tests__/composition.spec.ts
+++ b/__tests__/composition.spec.ts
@@ -7757,4 +7757,64 @@ testImplementations((api) => {
       }
     `);
   });
+
+  test("@tag usage without 'name' argument raises no exception", () => {
+    const result = api.composeServices([
+      {
+        name: "a service",
+        typeDefs: parse(/* GraphQL */ `
+          extend schema
+            @link(url: "https://specs.apollo.dev/link/v1.0")
+            @link(
+              url: "https://specs.apollo.dev/federation/v2.0"
+              import: ["@tag"]
+            )
+
+          type Query {
+            ping: String
+            pong: String
+            foo: User @tag
+          }
+
+          type User {
+            id: ID!
+          }
+        `),
+      },
+    ]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors?.at(0)?.message).toContain(
+      `Directive "@tag" argument "name" of type "String!" is required, but it was not provided.`,
+    );
+  });
+
+  test("@tag usage with wrong 'name' argument type raises no exception", () => {
+    const result = api.composeServices([
+      {
+        name: "a service",
+        typeDefs: parse(/* GraphQL */ `
+          extend schema
+            @link(url: "https://specs.apollo.dev/link/v1.0")
+            @link(
+              url: "https://specs.apollo.dev/federation/v2.0"
+              import: ["@tag"]
+            )
+
+          type Query {
+            ping: String
+            pong: String
+            foo: User @tag(name: {})
+          }
+
+          type User {
+            id: ID!
+          }
+        `),
+      },
+    ]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors?.at(0)?.message).toContain(
+      `Invalid value for "@tag(name:)" of type "String!" in application of "@tag" to "Query.foo".`,
+    );
+  });
 });

--- a/src/subgraph/validation/rules/elements/tag.ts
+++ b/src/subgraph/validation/rules/elements/tag.ts
@@ -15,11 +15,11 @@ export function TagRules(context: SubgraphValidationContext): ASTVisitor {
       const nameArg = node.arguments?.find((arg) => arg.name.value === "name");
 
       if (!nameArg) {
-        throw new Error('Expected @tag to have a "name" argument');
+        return;
       }
 
       if (nameArg.value.kind !== Kind.STRING) {
-        throw new Error('Expected "@tag(name:)" to be a string');
+        return;
       }
 
       const directivesKeyAt = paths.findIndex((path) => path === "directives");


### PR DESCRIPTION
This aligns our implementation to not throw errors.