### PR TITLE
fix: invalid external unused error when using union selection set in `requires`

### DIFF
--- a/.changeset/five-bobcats-crash.md
+++ b/.changeset/five-bobcats-crash.md
@@ -1,0 +1,5 @@
+---
+"@theguild/federation-composition": patch
+---
+
+Resolve usage of `@requires` `FieldSet` with a union field selection to raise an `EXTERNAL_UNUSED` error.

--- a/__tests__/subgraph/errors/EXTERNAL_UNUSED.spec.ts
+++ b/__tests__/subgraph/errors/EXTERNAL_UNUSED.spec.ts
@@ -84,6 +84,74 @@ testVersions((api, version) => {
     );
   });
 
+  test("EXTERNAL_UNUSED on requires with union selection set does not raise an error", () => {
+    const errors = api.composeServices([
+      {
+        name: "users",
+        typeDefs: graphql`
+          extend schema
+            @link(
+              url: "https://specs.apollo.dev/federation/${version}"
+              import: ["@key", "@external", "@requires"]
+            )
+
+            enum Status {
+              ACTIVE
+              CANCELLED
+              EXPIRED
+            }
+
+            type EntityA {
+              status: Status! @external
+            }
+
+
+            union UnionType = EntityA
+
+            extend type FederatedEntity  @key(fields: "id") {
+              id: ID!
+              requiredField: UnionType @external
+              providedField: String! @requires(fields: "requiredField { ...on EntityA { status } } ")
+            }
+        `,
+      },
+      {
+        name: "entities",
+        typeDefs: graphql`
+        extend schema
+          @link(
+            url: "https://specs.apollo.dev/federation/${version}"
+            import: ["@key", "@external", "@requires"]
+          )
+
+          enum Status {
+            ACTIVE
+            CANCELLED
+            EXPIRED
+          }
+
+          type EntityA @key(fields: "id") {
+            id: ID!
+            status: Status!
+          }
+
+          union UnionType = EntityA
+
+          type FederatedEntity @key(fields: "id") {
+            id: ID!
+            requiredField: UnionType
+          }
+
+          type Query {
+            a(id: ID): FederatedEntity
+          }
+        `,
+      },
+    ]).errors;
+
+    expect(errors).toEqual(undefined);
+  });
+
   test("Fed v1: No EXTERNAL_UNUSED", () => {
     const result = api.composeServices([
       {

--- a/__tests__/subgraph/errors/EXTERNAL_UNUSED.spec.ts
+++ b/__tests__/subgraph/errors/EXTERNAL_UNUSED.spec.ts
@@ -108,7 +108,7 @@ testVersions((api, version) => {
 
             union UnionType = EntityA
 
-            extend type FederatedEntity  @key(fields: "id") {
+            extend type FederatedEntity @key(fields: "id") {
               id: ID!
               requiredField: UnionType @external
               providedField: String! @requires(fields: "requiredField { ...on EntityA { status } } ")

--- a/src/subgraph/helpers.ts
+++ b/src/subgraph/helpers.ts
@@ -396,7 +396,6 @@ export function visitFields({
               outputType: print(selectionFieldDef.type),
             });
           }
-          // continue;
           return;
         }
 


### PR DESCRIPTION
We are not visiting the selection sets of union types when validating whether a external field definition is used.