### PR TITLE
fix: check for external on parent type

### DIFF
--- a/src/subgraph/helpers.ts
+++ b/src/subgraph/helpers.ts
@@ -331,9 +331,13 @@ export function visitFields({
     }
 
     if (!isTypename && (interceptNonExternalField || interceptExternalField)) {
-      const isExternal = selectionFieldDef.directives?.some((d) =>
-        context.isAvailableFederationDirective("external", d),
-      );
+      const isExternal =
+        selectionFieldDef.directives?.some((d) =>
+          context.isAvailableFederationDirective("external", d),
+        ) ||
+        typeDefinition.directives?.some((d) =>
+          context.isAvailableFederationDirective("external", d),
+        );
       const fieldName = selection.name.value;
 
       // ignore if it's not a leaf


### PR DESCRIPTION
Adds support for `@external` on types. According to the spec (https://www.apollographql.com/docs/graphos/schema-design/federated-schemas/reference/directives#external) if `@external` is defined on the type, then all fields inside that type are considered external.