### PR TITLE
Add GraphQL v14 and v15 Support

### DIFF
--- a/.changeset/dirty-humans-prove.md
+++ b/.changeset/dirty-humans-prove.md
@@ -1,0 +1,5 @@
+---
+"@theguild/federation-composition": patch
+---
+
+tag extraction respects @external on parent

--- a/__tests__/composition.spec.ts
+++ b/__tests__/composition.spec.ts
@@ -7382,8 +7382,8 @@ testImplementations((api) => {
         typeDefs: parse(/* GraphQL */ `
           extend schema
             @link(
-            url: "https://specs.apollo.dev/federation/v2.3"
-            import: ["@key", "@shareable"]
+              url: "https://specs.apollo.dev/federation/v2.3"
+              import: ["@key", "@shareable"]
             )
           type Note @key(fields: "id") @shareable {
             id: ID!
@@ -7391,16 +7391,16 @@ testImplementations((api) => {
             author: User
           }
           type User @key(fields: "id") {
-          id: ID!
-          name: String
+            id: ID!
+            name: String
           }
-        type PrivateNote @key(fields: "id") @shareable {
-          id: ID!
-          note: Note
-        }
-        type Query {
-          note: Note @shareable
-          privateNote: PrivateNote @shareable
+          type PrivateNote @key(fields: "id") @shareable {
+            id: ID!
+            note: Note
+          }
+          type Query {
+            note: Note @shareable
+            privateNote: PrivateNote @shareable
           }
         `),
       },
@@ -7425,9 +7425,9 @@ testImplementations((api) => {
     result = api.composeServices([
       {
         name: "foo",
-          typeDefs: parse(/* GraphQL */ `
+        typeDefs: parse(/* GraphQL */ `
           extend schema
-              @link(
+            @link(
               url: "https://specs.apollo.dev/federation/v2.3"
               import: ["@key", "@external", "@provides", "@shareable"]
             )
@@ -7442,8 +7442,8 @@ testImplementations((api) => {
           type PrivateNote @key(fields: "id") @shareable {
             id: ID!
             note: Note @provides(fields: "name author { id }")
-            }
-            type Query {
+          }
+          type Query {
             note: Note @shareable
             privateNote: PrivateNote @shareable
           }
@@ -7461,8 +7461,8 @@ testImplementations((api) => {
             id: ID!
             name: String
             author: User
-            }
-            type User @key(fields: "id") {
+          }
+          type User @key(fields: "id") {
             id: ID!
             name: String
           }
@@ -7490,7 +7490,7 @@ testImplementations((api) => {
           type Note @key(fields: "id") @shareable {
             id: ID!
             tag: String
-            }
+          }
         `),
       },
     ]);
@@ -7510,7 +7510,7 @@ testImplementations((api) => {
           @join__field(external: true, graph: FOO)
           @join__field(graph: BAR)
         tag: String @join__field(graph: BAZ)
-        }
+      }
     `);
   });
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "typecheck": "tsc --noEmit --project tsconfig.build.json"
   },
   "peerDependencies": {
-    "graphql": "^16.0.0"
+    "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
     "constant-case": "^3.0.4",

--- a/src/contracts/tag-extraction.ts
+++ b/src/contracts/tag-extraction.ts
@@ -458,7 +458,8 @@ export function applyTagFilterToInaccessibleTransformOnSubgraphSchema(
           if (
             fieldNode.directives?.find(
               (d) => d.name.value === externalDirectiveName,
-            ) || node.directives?.find(d => d.name.value === externalDirectiveName)
+            ) ||
+            node.directives?.find((d) => d.name.value === externalDirectiveName)
           ) {
             return fieldNode;
           }

--- a/src/contracts/tag-extraction.ts
+++ b/src/contracts/tag-extraction.ts
@@ -458,7 +458,7 @@ export function applyTagFilterToInaccessibleTransformOnSubgraphSchema(
           if (
             fieldNode.directives?.find(
               (d) => d.name.value === externalDirectiveName,
-            )
+            ) || node.directives?.find(d => d.name.value === externalDirectiveName)
           ) {
             return fieldNode;
           }

--- a/src/subgraph/state.ts
+++ b/src/subgraph/state.ts
@@ -8,7 +8,7 @@ import {
   Kind,
   ObjectTypeDefinitionNode,
   ObjectTypeExtensionNode,
-  OperationTypeNode,
+  type OperationTypeNode,
   SchemaDefinitionNode,
   specifiedDirectives as specifiedDirectiveTypes,
   specifiedScalarTypes,
@@ -398,17 +398,17 @@ export function createSubgraphStateBuilder(
 
   const expectedQueryTypeName = decideOnRootTypeName(
     schemaDef,
-    OperationTypeNode.QUERY,
+    'query' as OperationTypeNode,
     "Query",
   );
   const expectedMutationTypeName = decideOnRootTypeName(
     schemaDef,
-    OperationTypeNode.MUTATION,
+    'mutation' as OperationTypeNode,
     "Mutation",
   );
   const expectedSubscriptionTypeName = decideOnRootTypeName(
     schemaDef,
-    OperationTypeNode.SUBSCRIPTION,
+    'subscription' as OperationTypeNode,
     "Subscription",
   );
 

--- a/src/subgraph/validation/rules/known-directives-rule.ts
+++ b/src/subgraph/validation/rules/known-directives-rule.ts
@@ -5,7 +5,7 @@ import {
   DocumentNode,
   GraphQLError,
   Kind,
-  OperationTypeNode,
+  type OperationTypeNode,
   specifiedDirectives,
 } from "graphql";
 
@@ -135,11 +135,11 @@ function getDirectiveLocationForOperation(
   operation: OperationTypeNode,
 ): DirectiveLocation {
   switch (operation) {
-    case OperationTypeNode.QUERY:
+    case 'query' as OperationTypeNode.QUERY:
       return DirectiveLocation.QUERY;
-    case OperationTypeNode.MUTATION:
+    case 'mutation' as OperationTypeNode.MUTATION:
       return DirectiveLocation.MUTATION;
-    case OperationTypeNode.SUBSCRIPTION:
+    case 'subscription' as OperationTypeNode.SUBSCRIPTION:
       return DirectiveLocation.SUBSCRIPTION;
   }
 }

--- a/src/subgraph/validation/rules/query-root-type-inaccessible-rule.ts
+++ b/src/subgraph/validation/rules/query-root-type-inaccessible-rule.ts
@@ -1,4 +1,4 @@
-import { ASTVisitor, GraphQLError, OperationTypeNode } from "graphql";
+import { ASTVisitor, GraphQLError, type OperationTypeNode } from "graphql";
 import type { SubgraphValidationContext } from "../validation-context.js";
 
 export function QueryRootTypeInaccessibleRule(
@@ -10,7 +10,7 @@ export function QueryRootTypeInaccessibleRule(
     SchemaDefinition(node) {
       const nonQueryType = node.operationTypes?.find(
         (operationType) =>
-          operationType.operation === OperationTypeNode.QUERY &&
+          operationType.operation === 'query' &&
           operationType.type.name.value !== "Query",
       );
 
@@ -21,7 +21,7 @@ export function QueryRootTypeInaccessibleRule(
     SchemaExtension(node) {
       const nonQueryType = node.operationTypes?.find(
         (operationType) =>
-          operationType.operation === OperationTypeNode.QUERY &&
+          operationType.operation === 'query' &&
           operationType.type.name.value !== "Query",
       );
 

--- a/src/subgraph/validation/rules/root-type-used-rule.ts
+++ b/src/subgraph/validation/rules/root-type-used-rule.ts
@@ -3,7 +3,7 @@ import {
   DefinitionNode,
   GraphQLError,
   isTypeDefinitionNode,
-  OperationTypeNode,
+  type OperationTypeNode,
   SchemaDefinitionNode,
   SchemaExtensionNode,
 } from "graphql";
@@ -26,13 +26,13 @@ function findDefaultRootTypes(definitions: readonly DefinitionNode[]) {
     if (isTypeDefinitionNode(definition)) {
       if (definition.name.value === "Query") {
         foundRootTypes.query = "Query";
-        found.add(OperationTypeNode.QUERY);
+        found.add('query' as OperationTypeNode);
       } else if (definition.name.value === "Mutation") {
         foundRootTypes.mutation = "Mutation";
-        found.add(OperationTypeNode.MUTATION);
+        found.add('mutation' as OperationTypeNode);
       } else if (definition.name.value === "Subscription") {
         foundRootTypes.subscription = "Subscription";
-        found.add(OperationTypeNode.SUBSCRIPTION);
+        found.add('subscription' as OperationTypeNode);
       }
     }
   }

--- a/src/subgraph/validation/validate-subgraph.ts
+++ b/src/subgraph/validation/validate-subgraph.ts
@@ -8,7 +8,6 @@ import {
   Kind,
   ObjectTypeDefinitionNode,
   ObjectTypeExtensionNode,
-  OperationTypeNode,
   parse,
   SchemaDefinitionNode,
   SchemaExtensionNode,
@@ -541,13 +540,13 @@ function cleanSubgraphTypeDefsFromSubgraphSpec(typeDefs: DocumentNode) {
       (node.kind === Kind.SCHEMA_DEFINITION ||
         node.kind === Kind.SCHEMA_EXTENSION) &&
       node.operationTypes?.some(
-        (op) => op.operation === OperationTypeNode.QUERY,
+        (op) => op.operation === 'query',
       ),
   ) as SchemaDefinitionNode | SchemaExtensionNode | undefined;
 
   const queryTypeName =
     schemaDef?.operationTypes?.find(
-      (op) => op.operation === OperationTypeNode.QUERY,
+      (op) => op.operation === 'query',
     )?.type.name.value ?? "Query";
 
   (typeDefs.definitions as unknown as DefinitionNode[]) =

--- a/src/supergraph/composition/ast.ts
+++ b/src/supergraph/composition/ast.ts
@@ -21,7 +21,7 @@ import {
   NamedTypeNode,
   ObjectTypeDefinitionNode,
   OperationTypeDefinitionNode,
-  OperationTypeNode,
+  type OperationTypeNode,
   parseConstValue,
   parseType,
   ScalarTypeDefinitionNode,
@@ -77,21 +77,21 @@ export function createSchemaNode(schema: {
       schema.query
         ? {
             kind: Kind.OPERATION_TYPE_DEFINITION,
-            operation: OperationTypeNode.QUERY,
+            operation: 'query' as OperationTypeNode,
             type: createNamedTypeNode(schema.query),
           }
         : [],
       schema.mutation
         ? {
             kind: Kind.OPERATION_TYPE_DEFINITION,
-            operation: OperationTypeNode.MUTATION,
+            operation: 'mutation' as OperationTypeNode,
             type: createNamedTypeNode(schema.mutation),
           }
         : [],
       schema.subscription
         ? {
             kind: Kind.OPERATION_TYPE_DEFINITION,
-            operation: OperationTypeNode.SUBSCRIPTION,
+            operation: 'subscription' as OperationTypeNode,
             type: createNamedTypeNode(schema.subscription),
           }
         : [],

--- a/src/supergraph/validation/rules/satisfiablity-rule.ts
+++ b/src/supergraph/validation/rules/satisfiablity-rule.ts
@@ -2,7 +2,6 @@ import {
   GraphQLError,
   Kind,
   ListValueNode,
-  OperationTypeNode,
   print,
   specifiedScalarTypes,
   ValueNode,

--- a/src/supergraph/validation/rules/satisfiablity/supergraph.ts
+++ b/src/supergraph/validation/rules/satisfiablity/supergraph.ts
@@ -1,4 +1,4 @@
-import { OperationTypeNode } from "graphql";
+import type { OperationTypeNode } from "graphql";
 import { Logger, LoggerContext } from "../../../../utils/logger.js";
 import type { SupergraphState } from "../../../state.js";
 import { MERGEDGRAPH_ID, SUPERGRAPH_ID } from "./constants.js";

--- a/src/supergraph/validation/rules/satisfiablity/walker.ts
+++ b/src/supergraph/validation/rules/satisfiablity/walker.ts
@@ -1,4 +1,4 @@
-import { OperationTypeNode } from "graphql";
+import type { OperationTypeNode } from "graphql";
 import type { Logger } from "../../../../utils/logger.js";
 import { isAbstractEdge, isFieldEdge, type Edge } from "./edge.js";
 import { LazyErrors, SatisfiabilityError } from "./errors.js";
@@ -119,9 +119,9 @@ export class Walker {
     }
 
     const rootNode = this.supergraph.nodeOf(
-      operationType === OperationTypeNode.QUERY
+      operationType === 'query'
         ? "Query"
-        : operationType === OperationTypeNode.MUTATION
+        : operationType === 'mutation'
           ? "Mutation"
           : "Subscription",
       false,


### PR DESCRIPTION
Federation composition is a very useful package, but we're being limited by its lack of support for some older versions of GraphQL. See: https://github.com/ardatan/graphql-tools/issues/7290

This PR adjusts how we're using using `OperationTypeNode` so that it isn't a required import any longer, which allows us to support these older versions.