### PR TITLE
fix: do not add inaccessible directive on federation built-in types

### DIFF
--- a/.changeset/lemon-pianos-slide.md
+++ b/.changeset/lemon-pianos-slide.md
@@ -1,0 +1,13 @@
+---
+"@theguild/federation-composition": patch
+---
+
+Fix schema contract composition applying `@inaccessible` on the federation types `ContextArgument` and `FieldValue` on the supergraph SDL.
+
+This mitigates the following error in apollo-router upon processing the supergraph:
+
+```
+could not create router: Api error(s): The supergraph schema failed to produce a valid API schema: The following errors occurred:
+  - Core feature type `join__ContextArgument` cannot use @inaccessible.
+  - Core feature type `join__FieldValue` cannot use @inaccessible.
+```

--- a/__tests__/contracts/add-inaccessible-to-unreachable-types.spec.ts
+++ b/__tests__/contracts/add-inaccessible-to-unreachable-types.spec.ts
@@ -98,3 +98,50 @@ test("Filters based on tags", async () => {
     }"
   `);
 });
+
+test("Inaccessible is not added on built-in Federation types ContextArgument ContextArgument and FieldValue", async () => {
+  const sdl = /* GraphQL */ `
+    extend schema
+      @link(url: "https://specs.apollo.dev/federation/v2.9", import: ["@key"])
+
+    type Query {
+      me: Me
+    }
+
+    type Me @key(fields: "id") {
+      id: ID!
+    }
+  `;
+
+  let compositionResult = composeServices([
+    {
+      name: "user",
+      url: "https://noop.graphql-hive.com",
+      typeDefs: parse(sdl),
+    },
+  ]);
+
+  expect(compositionResult.errors).toBe(undefined);
+  expect(compositionResult.supergraphSdl).not.toBe(undefined);
+  const { resolveImportName } = extractLinkImplementations(
+    parse(compositionResult.supergraphSdl!),
+  );
+
+  compositionResult = addInaccessibleToUnreachableTypes(
+    resolveImportName,
+    compositionResult as CompositionSuccess,
+  );
+
+  expect(compositionResult.supergraphSdl).to.include(
+    "scalar join__FieldValue\n",
+  );
+  expect(compositionResult.supergraphSdl).to.not.include(
+    "scalar join__FieldValue @inaccessible",
+  );
+  expect(compositionResult.supergraphSdl).to.not.include(
+    "input join__ContextArgument @inaccessible {",
+  );
+  expect(compositionResult.supergraphSdl).to.include(
+    "input join__ContextArgument {\n",
+  );
+});

--- a/__tests__/contracts/add-inaccessible-to-unreachable-types.spec.ts
+++ b/__tests__/contracts/add-inaccessible-to-unreachable-types.spec.ts
@@ -99,7 +99,7 @@ test("Filters based on tags", async () => {
   `);
 });
 
-test("Inaccessible is not added on built-in Federation types ContextArgument ContextArgument and FieldValue", async () => {
+test("Inaccessible is not added on built-in Federation types ContextArgument and FieldValue", async () => {
   const sdl = /* GraphQL */ `
     extend schema
       @link(url: "https://specs.apollo.dev/federation/v2.9", import: ["@key"])

--- a/src/contracts/add-inaccessible-to-unreachable-types.ts
+++ b/src/contracts/add-inaccessible-to-unreachable-types.ts
@@ -28,6 +28,8 @@ export const addInaccessibleToUnreachableTypes = (
     resolveName("https://specs.apollo.dev/federation", "Policy"),
     resolveName("https://specs.apollo.dev/federation", "Scope"),
     resolveName("https://specs.apollo.dev/join", "DirectiveArguments"),
+    resolveName("https://specs.apollo.dev/join", "ContextArgument"),
+    resolveName("https://specs.apollo.dev/join", "FieldValue"),
   ]);
 
   // we retrieve the list of reachable types from the public api sdl


### PR DESCRIPTION
ix schema contract composition applying `@inaccessible` on the federation types `ContextArgument` and `FieldValue` on the supergraph SDL.

This mitigates the following error in apollo-router upon processing the supergraph:

```
could not create router: Api error(s): The supergraph schema failed to produce a valid API schema: The following errors occurred:
  - Core feature type `join__ContextArgument` cannot use @inaccessible.
  - Core feature type `join__FieldValue` cannot use @inaccessible.
```