### PR TITLE
composition result differences for compose directives 

### DIFF
--- a/__tests__/supergraph/base.spec.ts
+++ b/__tests__/supergraph/base.spec.ts
@@ -521,6 +521,96 @@ testVersions((api, version) => {
       `);
     });
 
+    test("compose directive definition conflict (does the order matter? 1)", () => {
+      const result = api.composeServices([
+        {
+          name: "a",
+          url: "http://a.com",
+          typeDefs: graphql`
+          extend schema
+            @link(url: "https://specs.apollo.dev/federation/${version}", import: ["@composeDirective"])
+            @link(url: "https://a.dev/a/v1.0", import: ["@a"])
+            @composeDirective(name: "@a")
+
+          directive @a(name: String!) on QUERY | MUTATION
+
+          type Query {
+            a: Int
+          }
+        `,
+        },
+        {
+          name: "b",
+          url: "http://b.com",
+          typeDefs: graphql`
+          extend schema
+            @link(url: "https://specs.apollo.dev/federation/${version}", import: ["@composeDirective"])
+            @link(url: "https://a.dev/a/v1.0", import: ["@a"])
+            @composeDirective(name: "@a")
+
+
+        directive @a(name: ID!) on QUERY | MUTATION
+
+
+          type Query {
+            b: Int
+          }
+          `,
+        },
+      ]);
+
+      expect(result.errors).toEqual(undefined);
+      assertCompositionSuccess(result);
+      expect(result.supergraphSdl).toContainGraphQL(graphql`
+        directive @a(name: String!) on QUERY | MUTATION
+      `);
+    });
+
+    test("compose directive definition conflict (does the order matter? 2)", () => {
+      const result = api.composeServices([
+        {
+          name: "b",
+          url: "http://b.com",
+          typeDefs: graphql`
+          extend schema
+            @link(url: "https://specs.apollo.dev/federation/${version}", import: ["@composeDirective"])
+            @link(url: "https://a.dev/a/v1.0", import: ["@a"])
+            @composeDirective(name: "@a")
+
+
+            directive @a(name: ID!) on QUERY | MUTATION
+
+
+          type Query {
+            b: Int
+          }
+          `,
+        },
+        {
+          name: "a",
+          url: "http://a.com",
+          typeDefs: graphql`
+          extend schema
+            @link(url: "https://specs.apollo.dev/federation/${version}", import: ["@composeDirective"])
+            @link(url: "https://a.dev/a/v1.0", import: ["@a"])
+            @composeDirective(name: "@a")
+
+          directive @a(name: String!) on QUERY | MUTATION
+
+          type Query {
+            a: Int
+          }
+        `,
+        },
+      ]);
+
+      expect(result.errors).toEqual(undefined);
+      assertCompositionSuccess(result);
+      expect(result.supergraphSdl).toContainGraphQL(graphql`
+        directive @a(name: String!) on QUERY | MUTATION
+      `);
+    });
+
     test("composed directive with VARIABLE_DEFINITION and FIELD locations is preserved in supergraph", () => {
       const result = api.composeServices([
         {


### PR DESCRIPTION
The current apollo federation and guild federation libraries behave different on the non-happy path.

If the compose directives definition is different in all supgraph definitions:

The Guild composition raises an exception:

```
[
  GraphQLError {
    "message": "Type of argument \"@a(name:)\" is incompatible across subgraphs: it has type \"String!\" in subgraph \"a\" but type \"ID!\" in subgraph \"b\"",
    "path": undefined,
    "locations": undefined,
    "extensions": {
      "code": "FIELD_ARGUMENT_TYPE_MISMATCH",
    },
  },
]
```

The apollo federation composition chooses one definition that will win by sorting by service name descending (you can switch out the name of the services and see that the tests start passing on apollo federation) 😓 