### PR TITLE
fix: REQUIRED_INACCESSIBLE with default values

### DIFF
--- a/.changeset/hip-states-agree.md
+++ b/.changeset/hip-states-agree.md
@@ -1,0 +1,19 @@
+---
+"@theguild/federation-composition": patch
+---
+
+Fix `REQUIRED_INACCESSIBLE` composition rule reporting a composition error if `@inaccessible` is applied on a non-nullable field with a default value.
+
+In the following example schema the `Query.ping(message:)` argument no longer raises `REQUIRED_INACCESSIBLE`, as a default value for the argument is provided. The same behaviour applies for input type fields.
+
+```graphql
+extend schema
+  @link(
+    url: "https://specs.apollo.dev/federation/v2.9"
+    import: ["@inaccessible"]
+  )
+
+  type Query {
+    ping(message: String! = "pong" @inaccessible): String!
+  }
+```

--- a/__tests__/supergraph/errors/REQUIRED_INACCESSIBLE.spec.ts
+++ b/__tests__/supergraph/errors/REQUIRED_INACCESSIBLE.spec.ts
@@ -124,7 +124,6 @@ testVersions((api, version) => {
 
           type Query {
             a(id: String! = "brrry" @inaccessible): Int!
-            b: Int!
           }
         `,
         },

--- a/__tests__/supergraph/errors/REQUIRED_INACCESSIBLE.spec.ts
+++ b/__tests__/supergraph/errors/REQUIRED_INACCESSIBLE.spec.ts
@@ -42,7 +42,7 @@ testVersions((api, version) => {
                 url: "https://specs.apollo.dev/federation/${version}"
                 import: ["@key", "@inaccessible"]
               )
-              
+
             input A {
               id: ID! @inaccessible
               b: Int
@@ -104,6 +104,51 @@ testVersions((api, version) => {
 
           type Query {
             a(id: A! @inaccessible): Int! @inaccessible
+            b: Int!
+          }
+        `,
+        },
+      ])?.errors,
+    ).toBeUndefined();
+
+    expect(
+      api.composeServices([
+        {
+          name: "users",
+          typeDefs: graphql`
+          extend schema
+            @link(
+              url: "https://specs.apollo.dev/federation/${version}"
+              import: ["@inaccessible"]
+            )
+
+          type Query {
+            a(id: String! = "brrry" @inaccessible): Int!
+            b: Int!
+          }
+        `,
+        },
+      ])?.errors,
+    ).toBeUndefined();
+
+    expect(
+      api.composeServices([
+        {
+          name: "users",
+          typeDefs: graphql`
+          extend schema
+            @link(
+              url: "https://specs.apollo.dev/federation/${version}"
+              import: ["@inaccessible"]
+            )
+
+          input Foo {
+            a: String
+            b: String! = "he he he" @inaccessible
+          }
+
+          type Query {
+            a(id: Foo!): Int!
             b: Int!
           }
         `,

--- a/src/supergraph/validation/rules/required-argument-or-field-is-not-inaccessible-rule.ts
+++ b/src/supergraph/validation/rules/required-argument-or-field-is-not-inaccessible-rule.ts
@@ -10,7 +10,8 @@ export function RequiredArgumentOrFieldIsNotInaccessibleRule(
       if (
         !inputObjectState.inaccessible &&
         fieldState.inaccessible &&
-        fieldState.type.endsWith("!")
+        fieldState.type.endsWith("!") &&
+        fieldState.defaultValue === undefined
       ) {
         context.reportError(
           new GraphQLError(
@@ -28,7 +29,8 @@ export function RequiredArgumentOrFieldIsNotInaccessibleRule(
       if (
         !fieldState.inaccessible &&
         argState.inaccessible &&
-        argState.type.endsWith("!")
+        argState.type.endsWith("!") &&
+        argState.defaultValue === undefined
       ) {
         context.reportError(
           new GraphQLError(


### PR DESCRIPTION
Fix `REQUIRED_INACCESSIBLE` composition rule reporting a composition error if `@inaccessible` is applied on a non-nullable field with a default value.

In the following example schema the `Query.ping(message:)` argument no longer raises `REQUIRED_INACCESSIBLE`, as a default value for the argument is provided. The same behaviour applies for input type fields.

```graphql
extend schema
  @link(
    url: "https://specs.apollo.dev/federation/v2.9"
    import: ["@inaccessible"]
  )

  type Query {
    ping(message: String! = "pong" @inaccessible): String!
  }
```
