### PR TITLE
Support graphql oneOf directive without composeDirective

### DIFF
--- a/.changeset/tender-mirrors-fry.md
+++ b/.changeset/tender-mirrors-fry.md
@@ -1,0 +1,5 @@
+---
+"@theguild/federation-composition": minor
+---
+
+Support oneOf directive without using composeDirective

--- a/__tests__/composition.spec.ts
+++ b/__tests__/composition.spec.ts
@@ -1,4 +1,4 @@
-import { parse, print } from "graphql";
+import { assertValidSchema, buildSchema, parse, print } from "graphql";
 import { describe, expect, test } from "vitest";
 import { sortSDL } from "../src/graphql/sort-sdl.js";
 import { sdl as joinSDL } from "../src/specifications/join.js";
@@ -8648,14 +8648,20 @@ testImplementations((api) => {
     `);
   });
 
-  test("guild composition supports composing built-in directive (@oneOf)", () => {
-    api.runIf("guild", () => {
-      const result = api.composeServices([
-        {
-          name: "a",
-          typeDefs: parse(/* GraphQL */ `
+  describe.only(
+    "guild composition (@oneOf)",
+    { skip: api.library === "apollo" },
+    () => {
+      test("supports composing built-in directive", () => {
+        const result = api.composeServices([
+          {
+            name: "a",
+            typeDefs: parse(/* GraphQL */ `
               extend schema
-                @link(url: "https://specs.apollo.dev/federation/v2.0" import: ["@key"])
+                @link(
+                  url: "https://specs.apollo.dev/federation/v2.0"
+                  import: ["@key"]
+                )
 
               input HelloInput @oneOf {
                 world: String
@@ -8666,37 +8672,319 @@ testImplementations((api) => {
                 hello(input: HelloInput): String
               }
             `),
-        },
-      ]);
+          },
+        ]);
 
-      assertCompositionSuccess(result);
+        assertCompositionSuccess(result);
 
-      expect(result.supergraphSdl).toContainGraphQL(/* GraphQL */ `
-        input HelloInput @oneOf @join__type(graph: A) {
-          world: String
-          me: String
+        expect(result.supergraphSdl).toContainGraphQL(/* GraphQL */ `
+          input HelloInput @oneOf @join__type(graph: A) {
+            world: String
+            me: String
+          }
+        `);
+
+        expect(result.supergraphSdl).toContainGraphQL(/* GraphQL */ `
+          directive @oneOf on INPUT_OBJECT
+        `);
+
+        expect(result.publicSdl).toContainGraphQL(/* GraphQL */ `
+          input HelloInput @oneOf {
+            world: String
+            me: String
+          }
+        `);
+      });
+
+      test("merges built-in @oneOf with an explicitly linked and composed @oneOf definition", () => {
+        const result = api.composeServices([
+          {
+            name: "a",
+            typeDefs: parse(/* GraphQL */ `
+              extend schema
+                @link(
+                  url: "https://specs.apollo.dev/federation/v2.0"
+                  import: ["@key"]
+                )
+
+              input HelloInput @oneOf {
+                world: String
+                me: String
+              }
+
+              type Query {
+                hello(input: HelloInput): String
+              }
+            `),
+          },
+          {
+            name: "b",
+            typeDefs: parse(/* GraphQL */ `
+              extend schema
+                @link(
+                  url: "https://specs.apollo.dev/federation/v2.3"
+                  import: ["@key", "@composeDirective"]
+                )
+                @link(
+                  url: "https://spec.graphql.org/specified/v1.6"
+                  import: ["@oneOf"]
+                )
+                @composeDirective(name: "@oneOf")
+
+              directive @oneOf on INPUT_OBJECT
+
+              type Hello {
+                world: String
+              }
+
+              type Query {
+                greetings(input: GreetingsInput!): [Hello]
+              }
+
+              input GreetingsInput @oneOf {
+                hello: String
+                world: String
+              }
+            `),
+          },
+        ]);
+
+        assertCompositionSuccess(
+          result,
+          `Composition failed: ${JSON.stringify(result.errors)}`,
+        );
+      });
+
+      test("throws during composition when a manual @oneOf definition adds a conflicting required argument", () => {
+        expect(() =>
+          api.composeServices([
+            {
+              name: "a",
+              typeDefs: parse(/* GraphQL */ `
+                extend schema
+                  @link(
+                    url: "https://specs.apollo.dev/federation/v2.0"
+                    import: ["@key"]
+                  )
+
+                input HelloInput @oneOf {
+                  world: String
+                  me: String
+                }
+
+                type Query {
+                  hello(input: HelloInput): String
+                }
+              `),
+            },
+            {
+              name: "b",
+              typeDefs: parse(/* GraphQL */ `
+                extend schema
+                  @link(
+                    url: "https://specs.apollo.dev/federation/v2.3"
+                    import: ["@key", "@composeDirective"]
+                  )
+                  @link(
+                    url: "https://spec.graphql.org/specified/v1.6"
+                    import: ["@oneOf"]
+                  )
+                  @composeDirective(name: "@oneOf")
+
+                directive @oneOf(arg: String!) on INPUT_OBJECT | OBJECT
+
+                type Hello @oneOf(arg: "Test") {
+                  world: String
+                }
+
+                type Query {
+                  greetings: [Hello]
+                }
+              `),
+            },
+          ]),
+        ).toThrowErrorMatchingInlineSnapshot(`
+          [GraphQLError: The schema is not a valid GraphQL schema.. Caused by:
+          Directive "@oneOf" argument "arg" of type "String!" is required, but it was not provided.]
+        `);
+      });
+
+      test("composes successfully but outputs an unbuildable public SDL when a composed manual definition widens locations invalidly", () => {
+        const result = api.composeServices([
+          {
+            name: "a",
+            typeDefs: parse(/* GraphQL */ `
+              extend schema
+                @link(
+                  url: "https://specs.apollo.dev/federation/v2.0"
+                  import: ["@key"]
+                )
+
+              input HelloInput @oneOf {
+                world: String
+                me: String
+              }
+
+              type Query {
+                hello(input: HelloInput): String
+              }
+            `),
+          },
+          {
+            name: "b",
+            typeDefs: parse(/* GraphQL */ `
+              extend schema
+                @link(
+                  url: "https://specs.apollo.dev/federation/v2.3"
+                  import: ["@key", "@composeDirective"]
+                )
+                @link(
+                  url: "https://spec.graphql.org/specified/v1.6"
+                  import: ["@oneOf"]
+                )
+                @composeDirective(name: "@oneOf")
+
+              directive @oneOf on INPUT_OBJECT | OBJECT
+
+              type Hello @oneOf {
+                world: String
+              }
+
+              type Query {
+                greetings: [Hello]
+              }
+            `),
+          },
+        ]);
+
+        expect(result.errors).toBeUndefined();
+        expect(result.supergraphSdl).toBeDefined();
+
+        if (result.supergraphSdl !== undefined) {
+          // Verify the public SDL is corrupted because the engine's standard core definition
+          // overwrites subgraph B's wider locations, leaving `@oneOf` dangling on an OBJECT type.
+          expect(result.publicSdl).toContainGraphQL(
+            `directive @oneOf on INPUT_OBJECT`,
+          );
+          expect(result.publicSdl).toContainGraphQL(`type Hello @oneOf`);
+
+          expect(() => buildSchema(result.publicSdl)).toThrow(
+            `Directive "@oneOf" may not be used on OBJECT.`,
+          );
         }
-      `);
+      });
 
-      expect(result.supergraphSdl).toContainGraphQL(/* GraphQL */ `
-        directive @oneOf on INPUT_OBJECT
-      `);
+      test("composes successfully but outputs an unbuildable public SDL when a single subgraph defines an invalid, composed @oneOf", () => {
+        const result = api.composeServices([
+          {
+            name: "b",
+            typeDefs: parse(/* GraphQL */ `
+              extend schema
+                @link(
+                  url: "https://specs.apollo.dev/federation/v2.3"
+                  import: ["@key", "@composeDirective"]
+                )
+                @link(
+                  url: "https://spec.graphql.org/specified/v1.6"
+                  import: ["@oneOf"]
+                )
+                @composeDirective(name: "@oneOf")
 
-      expect(result.publicSdl).toContainGraphQL(/* GraphQL */ `
-        input HelloInput @oneOf
-        {
-          world: String
-          me: String
+              directive @oneOf on INPUT_OBJECT | OBJECT
+
+              type Hello @oneOf {
+                world: String
+              }
+
+              type Query {
+                greetings: [Hello]
+              }
+            `),
+          },
+        ]);
+
+        expect(result.errors).toBeUndefined();
+        expect(result.supergraphSdl).toBeDefined();
+
+        if (result.supergraphSdl !== undefined) {
+          // The composition engine's standard internal definition overrides the public schema output
+          expect(result.publicSdl).toContainGraphQL(
+            `directive @oneOf on INPUT_OBJECT`,
+          );
+
+          expect(() => buildSchema(result.publicSdl)).toThrow(
+            `Directive "@oneOf" may not be used on OBJECT.`,
+          );
         }
-      `);
+      });
 
-      expect(result.supergraphSdl).toContainGraphQL(/* GraphQL */ `
-        schema
-          @link(url: "https://specs.apollo.dev/link/v1.0")
-          @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
-          query: Query
+      test("strips custom @oneOf execution locations from the public SDL if it is not explicitly composed", () => {
+        const result = api.composeServices([
+          {
+            name: "b",
+            typeDefs: parse(/* GraphQL */ `
+              extend schema
+                @link(
+                  url: "https://specs.apollo.dev/federation/v2.3"
+                  import: ["@key"]
+                )
+
+              directive @oneOf on INPUT_OBJECT | OBJECT
+
+              type Hello @oneOf {
+                world: String
+              }
+
+              type Query {
+                greetings: [Hello]
+              }
+            `),
+          },
+        ]);
+
+        expect(result.errors).toBeUndefined();
+        expect(result.supergraphSdl).toBeDefined();
+        if (result.supergraphSdl !== undefined) {
+          expect(() => buildSchema(result.publicSdl)).not.toThrow();
+          // Ensure internal directive use on the OBJECT type doesn't leak to public graph
+          expect(result.publicSdl).not.toContainGraphQL(`type Hello @oneOf`);
         }
-      `);
-    })
-  });
+      });
+
+      test("allows a local, uncomposed @oneOf matching the spec to surface implicitly on public input objects", () => {
+        const result = api.composeServices([
+          {
+            name: "b",
+            typeDefs: parse(/* GraphQL */ `
+              extend schema
+                @link(
+                  url: "https://specs.apollo.dev/federation/v2.3"
+                  import: ["@key"]
+                )
+
+              directive @oneOf on INPUT_OBJECT
+
+              input GreetingsInput @oneOf {
+                hello: String
+                world: String
+              }
+
+              type Query {
+                greetings(input: GreetingsInput!): String
+              }
+            `),
+          },
+        ]);
+
+        expect(result.errors).toBeUndefined();
+        expect(result.supergraphSdl).toBeDefined();
+        if (result.supergraphSdl !== undefined) {
+          expect(() => buildSchema(result.publicSdl)).not.toThrow();
+          expect(result.publicSdl).toContainGraphQL(
+            `input GreetingsInput @oneOf`,
+          );
+        }
+      });
+    },
+  );
 });

--- a/__tests__/composition.spec.ts
+++ b/__tests__/composition.spec.ts
@@ -8647,4 +8647,56 @@ testImplementations((api) => {
       }
     `);
   });
+
+  test("guild composition supports composing built-in directive (@oneOf)", () => {
+    api.runIf("guild", () => {
+      const result = api.composeServices([
+        {
+          name: "a",
+          typeDefs: parse(/* GraphQL */ `
+              extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0" import: ["@key"])
+
+              input HelloInput @oneOf {
+                world: String
+                me: String
+              }
+
+              type Query {
+                hello(input: HelloInput): String
+              }
+            `),
+        },
+      ]);
+
+      assertCompositionSuccess(result);
+
+      expect(result.supergraphSdl).toContainGraphQL(/* GraphQL */ `
+        input HelloInput @oneOf @join__type(graph: A) {
+          world: String
+          me: String
+        }
+      `);
+
+      expect(result.supergraphSdl).toContainGraphQL(/* GraphQL */ `
+        directive @oneOf on INPUT_OBJECT
+      `);
+
+      expect(result.publicSdl).toContainGraphQL(/* GraphQL */ `
+        input HelloInput @oneOf
+        {
+          world: String
+          me: String
+        }
+      `);
+
+      expect(result.supergraphSdl).toContainGraphQL(/* GraphQL */ `
+        schema
+          @link(url: "https://specs.apollo.dev/link/v1.0")
+          @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+          query: Query
+        }
+      `);
+    })
+  });
 });

--- a/__tests__/composition.spec.ts
+++ b/__tests__/composition.spec.ts
@@ -8696,6 +8696,52 @@ testImplementations((api) => {
         `);
       });
 
+      test("supports composing built-in directive (with matching definition)", () => {
+        const result = api.composeServices([
+          {
+            name: "a",
+            typeDefs: parse(/* GraphQL */ `
+              extend schema
+                @link(
+                  url: "https://specs.apollo.dev/federation/v2.0"
+                  import: ["@key"]
+                )
+
+              directive @oneOf on INPUT_OBJECT
+
+              input HelloInput @oneOf {
+                world: String
+                me: String
+              }
+
+              type Query {
+                hello(input: HelloInput): String
+              }
+            `),
+          },
+        ]);
+
+        assertCompositionSuccess(result);
+
+        expect(result.supergraphSdl).toContainGraphQL(/* GraphQL */ `
+          input HelloInput @oneOf @join__type(graph: A) {
+            world: String
+            me: String
+          }
+        `);
+
+        expect(result.supergraphSdl).toContainGraphQL(/* GraphQL */ `
+          directive @oneOf on INPUT_OBJECT
+        `);
+
+        expect(result.publicSdl).toContainGraphQL(/* GraphQL */ `
+          input HelloInput @oneOf {
+            world: String
+            me: String
+          }
+        `);
+      });
+
       test("merges built-in @oneOf with an explicitly linked and composed @oneOf definition", () => {
         const result = api.composeServices([
           {
@@ -8753,6 +8799,25 @@ testImplementations((api) => {
           result,
           `Composition failed: ${JSON.stringify(result.errors)}`,
         );
+        expect(result.errors).toBeUndefined();
+        expect(result.supergraphSdl).toBeDefined();
+        if (result.supergraphSdl !== undefined) {
+          expect(() => buildSchema(result.supergraphSdl)).not.toThrow();
+          expect(result.supergraphSdl).toContainGraphQL(
+            `directive @oneOf on INPUT_OBJECT`,
+          );
+          expect(result.supergraphSdl).toContainGraphQL(
+            `input GreetingsInput @join__type(graph: B) @oneOf`,
+          );
+          expect(result.supergraphSdl).toContainGraphQL(
+            `input HelloInput @join__type(graph: A) @oneOf`,
+          );
+          expect(() => buildSchema(result.publicSdl)).not.toThrow();
+          expect(result.publicSdl).toContainGraphQL(`input HelloInput @oneOf`);
+          expect(result.publicSdl).toContainGraphQL(
+            `input GreetingsInput @oneOf`,
+          );
+        }
       });
 
       test("throws during composition when a manual @oneOf definition adds a conflicting required argument", () => {
@@ -8816,7 +8881,7 @@ testImplementations((api) => {
             typeDefs: parse(/* GraphQL */ `
               extend schema
                 @link(
-                  url: "https://specs.apollo.dev/federation/v2.0"
+                  url: "https://specs.apollo.dev/federation/v2.3"
                   import: ["@key"]
                 )
 
@@ -8824,6 +8889,8 @@ testImplementations((api) => {
                 world: String
                 me: String
               }
+
+              directive @oneOf on INPUT_OBJECT
 
               type Query {
                 hello(input: HelloInput): String
@@ -8861,13 +8928,12 @@ testImplementations((api) => {
         expect(result.supergraphSdl).toBeDefined();
 
         if (result.supergraphSdl !== undefined) {
+          expect(result.supergraphSdl).toContainGraphQL(
+            `directive @oneOf on INPUT_OBJECT | OBJECT`,
+          );
+          expect(() => buildSchema(result.supergraphSdl)).not.toThrow();
           // Verify the public SDL is corrupted because the engine's standard core definition
           // overwrites subgraph B's wider locations, leaving `@oneOf` dangling on an OBJECT type.
-          expect(result.publicSdl).toContainGraphQL(
-            `directive @oneOf on INPUT_OBJECT`,
-          );
-          expect(result.publicSdl).toContainGraphQL(`type Hello @oneOf`);
-
           expect(() => buildSchema(result.publicSdl)).toThrow(
             `Directive "@oneOf" may not be used on OBJECT.`,
           );
@@ -8908,7 +8974,7 @@ testImplementations((api) => {
 
         if (result.supergraphSdl !== undefined) {
           // The composition engine's standard internal definition overrides the public schema output
-          expect(result.publicSdl).toContainGraphQL(
+          expect(result.supergraphSdl).toContainGraphQL(
             `directive @oneOf on INPUT_OBJECT`,
           );
 
@@ -8918,7 +8984,7 @@ testImplementations((api) => {
         }
       });
 
-      test("strips custom @oneOf execution locations from the public SDL if it is not explicitly composed", () => {
+      test("strips custom @oneOf execution locations from the composed SDL if it is not explicitly composed", () => {
         const result = api.composeServices([
           {
             name: "b",
@@ -8945,13 +9011,19 @@ testImplementations((api) => {
         expect(result.errors).toBeUndefined();
         expect(result.supergraphSdl).toBeDefined();
         if (result.supergraphSdl !== undefined) {
+          expect(result.supergraphSdl).not.toContainGraphQL(
+            `directive @oneOf on INPUT_OBJECT | OBJECT`,
+          );
+          expect(result.supergraphSdl).not.toContainGraphQL(
+            `type Hello @oneOf`,
+          );
           expect(() => buildSchema(result.publicSdl)).not.toThrow();
           // Ensure internal directive use on the OBJECT type doesn't leak to public graph
           expect(result.publicSdl).not.toContainGraphQL(`type Hello @oneOf`);
         }
       });
 
-      test("allows a local, uncomposed @oneOf matching the spec to surface implicitly on public input objects", () => {
+      test("allows an uncomposed @oneOf matching the spec to surface implicitly on public input objects", () => {
         const result = api.composeServices([
           {
             name: "b",
@@ -8976,10 +9048,14 @@ testImplementations((api) => {
           },
         ]);
 
-        expect(result.errors).toBeUndefined();
-        expect(result.supergraphSdl).toBeDefined();
+        assertCompositionSuccess(result);
         if (result.supergraphSdl !== undefined) {
-          expect(() => buildSchema(result.publicSdl)).not.toThrow();
+          expect(result.supergraphSdl).toContainGraphQL(
+            `directive @oneOf on INPUT_OBJECT`,
+          );
+          expect(result.supergraphSdl).toContainGraphQL(
+            `input GreetingsInput @join__type(graph: B) @oneOf`,
+          );
           expect(result.publicSdl).toContainGraphQL(
             `input GreetingsInput @oneOf`,
           );

--- a/__tests__/composition.spec.ts
+++ b/__tests__/composition.spec.ts
@@ -8648,7 +8648,7 @@ testImplementations((api) => {
     `);
   });
 
-  describe.only(
+  describe(
     "guild composition (@oneOf)",
     { skip: api.library === "apollo" },
     () => {

--- a/src/subgraph/state.ts
+++ b/src/subgraph/state.ts
@@ -2265,7 +2265,7 @@ function inputObjectTypeFactory(state: SubgraphState) {
     setOneOf(typeName: string) {
       const existingOneOf = state.types.get("oneOf");
 
-      // if definition matches the build-in, flag the type as isOneOf
+      // if definition matches the built-in, flag the type as isOneOf
       // and ensure the directive is composed
       if (
         existingOneOf &&

--- a/src/subgraph/state.ts
+++ b/src/subgraph/state.ts
@@ -1038,9 +1038,9 @@ export function createSubgraphStateBuilder(
             if (
               typeDef &&
               (typeDef.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION ||
-              typeDef.kind === Kind.INPUT_OBJECT_TYPE_EXTENSION)
+                typeDef.kind === Kind.INPUT_OBJECT_TYPE_EXTENSION)
             ) {
-              inputObjectTypeBuilder.setOneOf(typeDef.name.value)
+              inputObjectTypeBuilder.setOneOf(typeDef.name.value);
             }
           }
         },
@@ -2262,14 +2262,27 @@ function inputObjectTypeFactory(state: SubgraphState) {
     setTag(typeName: string, tag: string) {
       getOrCreateInputObjectType(state, typeName).tags.add(tag);
     },
-    setOneOf(
-      typeName: string,
-    ) {
-      getOrCreateInputObjectType(state, typeName).isOneOf =
-        true;
-      const oneOfDirective = getOrCreateDirective(state, 'oneOf');
-      oneOfDirective.locations.add(DirectiveLocation.INPUT_OBJECT);
-      oneOfDirective.composed = true; // force including in the composed output
+    setOneOf(typeName: string) {
+      const existingOneOf = state.types.get("oneOf");
+      // if there is an existing oneOf definition, then leave it as it is defined. Otherwise,
+      // create one
+      const oneOfDirective = getOrCreateDirective(state, "oneOf");
+      if (!existingOneOf) {
+        oneOfDirective.locations.add(DirectiveLocation.INPUT_OBJECT);
+        oneOfDirective.composed = true; // force including in the composed output
+      }
+
+      // if definition doesn't match the build-in's, then assume it's custom
+      // and skip flagging the type as oneOf. We should let composeDirective handle this
+      if (
+        oneOfDirective.locations.size === 1 &&
+        oneOfDirective.locations.has(DirectiveLocation.INPUT_OBJECT) &&
+        oneOfDirective.repeatable == false &&
+        oneOfDirective.args.size === 0
+      ) {
+        oneOfDirective.composed = true; // make sure it's composed
+        getOrCreateInputObjectType(state, typeName).isOneOf = true;
+      }
     },
     field: {
       setType(typeName: string, fieldName: string, fieldType: string) {

--- a/src/subgraph/state.ts
+++ b/src/subgraph/state.ts
@@ -2264,25 +2264,32 @@ function inputObjectTypeFactory(state: SubgraphState) {
     },
     setOneOf(typeName: string) {
       const existingOneOf = state.types.get("oneOf");
-      // if there is an existing oneOf definition, then leave it as it is defined. Otherwise,
-      // create one
-      const oneOfDirective = getOrCreateDirective(state, "oneOf");
-      if (!existingOneOf) {
-        oneOfDirective.locations.add(DirectiveLocation.INPUT_OBJECT);
-        oneOfDirective.composed = true; // force including in the composed output
-      }
 
-      // if definition doesn't match the build-in's, then assume it's custom
-      // and skip flagging the type as oneOf. We should let composeDirective handle this
+      // if definition matches the build-in, flag the type as isOneOf
+      // and ensure the directive is composed
       if (
-        oneOfDirective.locations.size === 1 &&
-        oneOfDirective.locations.has(DirectiveLocation.INPUT_OBJECT) &&
-        oneOfDirective.repeatable == false &&
-        oneOfDirective.args.size === 0
+        existingOneOf &&
+        existingOneOf.kind === TypeKind.DIRECTIVE &&
+        existingOneOf.locations.size === 1 &&
+        existingOneOf.locations.has(DirectiveLocation.INPUT_OBJECT) &&
+        !existingOneOf.repeatable &&
+        existingOneOf.args.size === 0
       ) {
-        oneOfDirective.composed = true; // make sure it's composed
+        existingOneOf.composed = true; // make sure it's composed
         getOrCreateInputObjectType(state, typeName).isOneOf = true;
       }
+
+      // If there is no existing definition, then this must be referencing the built-in.
+      // Create the definition and flag the type as isOneOf
+      else if (!existingOneOf) {
+        const oneOfDirective = getOrCreateDirective(state, "oneOf");
+        oneOfDirective.locations.add(DirectiveLocation.INPUT_OBJECT);
+        oneOfDirective.composed = true; // force including in the composed output
+
+        getOrCreateInputObjectType(state, typeName).isOneOf = true;
+      }
+
+      // otherwise let composeDirective figure it out
     },
     field: {
       setType(typeName: string, fieldName: string, fieldType: string) {

--- a/src/subgraph/state.ts
+++ b/src/subgraph/state.ts
@@ -140,6 +140,7 @@ export interface InputObjectType {
   ast: {
     directives: DirectiveNode[];
   };
+  isOneOf?: boolean;
 }
 
 export interface UnionType {
@@ -1031,6 +1032,15 @@ export function createSubgraphStateBuilder(
 
                 break;
               }
+            }
+          } else if (node.name.value === "oneOf") {
+            const typeDef = typeNodeInfo.getTypeDef();
+            if (
+              typeDef &&
+              (typeDef.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION ||
+              typeDef.kind === Kind.INPUT_OBJECT_TYPE_EXTENSION)
+            ) {
+              inputObjectTypeBuilder.setOneOf(typeDef.name.value)
             }
           }
         },
@@ -2251,6 +2261,15 @@ function inputObjectTypeFactory(state: SubgraphState) {
     },
     setTag(typeName: string, tag: string) {
       getOrCreateInputObjectType(state, typeName).tags.add(tag);
+    },
+    setOneOf(
+      typeName: string,
+    ) {
+      getOrCreateInputObjectType(state, typeName).isOneOf =
+        true;
+      const oneOfDirective = getOrCreateDirective(state, 'oneOf');
+      oneOfDirective.locations.add(DirectiveLocation.INPUT_OBJECT);
+      oneOfDirective.composed = true; // force including in the composed output
     },
     field: {
       setType(typeName: string, fieldName: string, fieldType: string) {

--- a/src/supergraph/composition/ast.ts
+++ b/src/supergraph/composition/ast.ts
@@ -197,6 +197,7 @@ export function createInputObjectTypeNode(inputObjectType: {
   tags?: string[];
   inaccessible?: boolean;
   description?: DescriptionAST;
+  isOneOf?: boolean;
   ast?: {
     directives?: ConstDirectiveNode[];
   };
@@ -786,6 +787,17 @@ function createInaccessibleDirectiveNode(): ConstDirectiveNode {
   };
 }
 
+function createOneOfDirectiveNode(): ConstDirectiveNode {
+  return {
+    kind: Kind.DIRECTIVE,
+    name: {
+      kind: Kind.NAME,
+      value: "oneOf",
+    },
+    arguments: [],
+  };
+}
+
 function createAuthenticatedDirectiveNode(): ConstDirectiveNode {
   return {
     kind: Kind.DIRECTIVE,
@@ -1219,6 +1231,7 @@ function applyDirectives(common: {
   scopes?: string[][];
   cost?: Cost | null;
   listSize?: ListSize | null;
+  isOneOf?: boolean;
 }) {
   const deduplicatedDirectives = (common.ast?.directives ?? [])
     .map((directive) => {
@@ -1253,6 +1266,7 @@ function applyDirectives(common: {
     common.specifiedBy
       ? [createSpecifiedByDirectiveNode(common.specifiedBy)]
       : [],
+    common.isOneOf ? [createOneOfDirectiveNode()] : [],
   );
 }
 

--- a/src/supergraph/composition/input-object-type.ts
+++ b/src/supergraph/composition/input-object-type.ts
@@ -32,6 +32,10 @@ export function inputObjectTypeBuilder(): TypeBuilder<
         inputObjectTypeState.hasDefinition = true;
       }
 
+      if (type.isOneOf) {
+        inputObjectTypeState.isOneOf = true;
+      }
+
       if (type.ast.directives) {
         type.ast.directives.forEach((directive) => {
           inputObjectTypeState.ast.directives.push(directive);
@@ -99,6 +103,7 @@ export function inputObjectTypeBuilder(): TypeBuilder<
         tags: Array.from(inputObjectType.tags),
         inaccessible: inputObjectType.inaccessible,
         description: inputObjectType.description,
+        isOneOf: inputObjectType.isOneOf,
         ast: {
           directives: convertToConst(inputObjectType.ast.directives),
         },
@@ -168,6 +173,7 @@ export interface InputObjectTypeState {
   inaccessible: boolean;
   hasDefinition: boolean;
   description?: Description;
+  isOneOf?: boolean;
   byGraph: MapByGraph<InputObjectTypeStateInGraph>;
   fields: Map<string, InputObjectTypeFieldState>;
   ast: {


### PR DESCRIPTION
Apollo doesn't support oneOf because they are using an out dated version of graphql.

This PR adds functionality to keep the oneOf directives through composition and adds a test to ensure this works.

This avoids having to unnecessarily add `@composeDirective` for `@oneOf`. `@composeDirective` should be reserved for custom directives instead of native directives.