### PR TITLE
feat: support graphql-js 17

### DIFF
--- a/.changeset/short-yaks-tease.md
+++ b/.changeset/short-yaks-tease.md
@@ -1,0 +1,5 @@
+---
+"@theguild/federation-composition": minor
+---
+
+Support GraphQL.js 17 as a peer dependency alongside GraphQL.js 16.

--- a/__tests__/composition.spec.ts
+++ b/__tests__/composition.spec.ts
@@ -1744,7 +1744,7 @@ testImplementations((api) => {
         expect(result.errors).toContainEqual(
           expect.objectContaining({
             message: expect.stringContaining(
-              'Directive "@access" argument "scope" of type "Scope!" is required, but it was not provided.',
+              'Argument "@access(scope:)" of type "Scope!" is required, but it was not provided.',
             ),
           }),
         );
@@ -8493,7 +8493,7 @@ testImplementations((api) => {
     ]);
     expect(result.errors).toHaveLength(1);
     expect(result.errors?.at(0)?.message).toContain(
-      `Directive "@tag" argument "name" of type "String!" is required, but it was not provided.`,
+      `Argument "@tag(name:)" of type "String!" is required, but it was not provided.`,
     );
   });
 
@@ -9318,7 +9318,7 @@ testImplementations((api) => {
             },
           ]),
         ).toThrow(`The schema is not a valid GraphQL schema.. Caused by:
-Directive "@oneOf" argument "arg" of type "String!" is required, but it was not provided.`);
+Argument "@oneOf(arg:)" of type "String!" is required, but it was not provided.`);
       });
 
       test("composes successfully when a composed manual definition widens specified directive locations", () => {

--- a/__tests__/contracts/federation-tag-extraction.spec.ts
+++ b/__tests__/contracts/federation-tag-extraction.spec.ts
@@ -174,7 +174,7 @@ describe("applyTagFilterToInaccessibleTransformOnSubgraphSchema", () => {
         ).typeDefs,
       );
       expect(outputSdl).toMatchInlineSnapshot(`
-        "schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: [{name: "@inaccessible", as: "@inaccessible__federation"}]) {
+        "schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: [{ name: "@inaccessible", as: "@inaccessible__federation" }]) {
           query: Query
         }
 

--- a/__tests__/subgraph/errors/INVALID_GRAPHQL.spec.ts
+++ b/__tests__/subgraph/errors/INVALID_GRAPHQL.spec.ts
@@ -149,7 +149,7 @@ testVersions((api, version) => {
             users(role: Role = "Oopsie"): [User]
             allUsers(role: Role = OOPSIE): [User]
             usersByIDs(ids: [ID!]! = []): [User]
-            usersByID(id: ID! = null): [User]
+            usersByID(id: ID! = NULL): [User]
             usersByID2(id: ID! = null): [User]
             filterUsers(filter: Filter = {
               role: "Oopsie"

--- a/__tests__/subgraph/errors/INVALID_GRAPHQL.spec.ts
+++ b/__tests__/subgraph/errors/INVALID_GRAPHQL.spec.ts
@@ -84,7 +84,7 @@ testVersions((api, version) => {
           expect.objectContaining({
             message: expect.stringContaining(
               // TODO: federation__FieldSet for Apollo `String!` for guild but it should be the same
-              `Directive "@provides" argument "fields" of type "${
+              `Argument "@provides(fields:)" of type "${
                 api.library === "guild" ? "FieldSet" : "federation__FieldSet"
               }!" is required, but it was not provided.`,
             ),
@@ -149,7 +149,7 @@ testVersions((api, version) => {
             users(role: Role = "Oopsie"): [User]
             allUsers(role: Role = OOPSIE): [User]
             usersByIDs(ids: [ID!]! = []): [User]
-            usersByID(id: ID! = NULL): [User]
+            usersByID(id: ID! = null): [User]
             usersByID2(id: ID! = null): [User]
             filterUsers(filter: Filter = {
               role: "Oopsie"

--- a/__tests__/supergraph/errors/SATISFIABILITY_ERROR.spec.ts
+++ b/__tests__/supergraph/errors/SATISFIABILITY_ERROR.spec.ts
@@ -802,7 +802,7 @@ testVersions((api, version) => {
             message: expect.stringContaining(
               "The following supergraph API query:\n" +
                 "{\n" +
-                '  users(filter: {limit: 0, after: "<any id>"}, role: ADMIN) {\n' +
+                '  users(filter: { limit: 0, after: "<any id>" }, role: ADMIN) {\n' +
                 "    age\n" +
                 "  }\n" +
                 "}\n" +

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "typecheck": "tsc --noEmit --project tsconfig.build.json"
   },
   "peerDependencies": {
-    "graphql": "^16.0.0"
+    "graphql": "^16.0.0 || ^17.0.0"
   },
   "dependencies": {
     "constant-case": "^3.0.4",
@@ -77,7 +77,7 @@
     "@types/node": "24.12.0",
     "@vitest/ui": "4.1.10",
     "bob-the-bundler": "7.0.1",
-    "graphql": "16.13.1",
+    "graphql": "17.0.2",
     "lodash.sortby": "4.7.0",
     "mitata": "1.0.34",
     "prettier": "3.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,10 +26,10 @@ importers:
     devDependencies:
       '@apollo/composition':
         specifier: 2.13.2
-        version: 2.13.2(graphql@16.13.1)
+        version: 2.13.2(graphql@17.0.2)
       '@apollo/federation-internals':
         specifier: 2.13.2
-        version: 2.13.2(graphql@16.13.1)
+        version: 2.13.2(graphql@17.0.2)
       '@changesets/changelog-github':
         specifier: 1.0.0
         version: 1.0.0
@@ -52,8 +52,8 @@ importers:
         specifier: 7.0.1
         version: 7.0.1(typescript@5.9.3)
       graphql:
-        specifier: 16.13.1
-        version: 16.13.1
+        specifier: 17.0.2
+        version: 17.0.2
       mitata:
         specifier: 1.0.34
         version: 1.0.34
@@ -781,9 +781,9 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  graphql@16.13.1:
-    resolution: {integrity: sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ==}
-    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+  graphql@17.0.2:
+    resolution: {integrity: sha512-FRWbddMxfkjiB7z+aQDWIR+E34xo9I8c9mtK2RPv8PmMzKRvrdsreHL/Ui/TmwHJfhHChEtsFPyMHKI+xuarQQ==}
+    engines: {node: ^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -1474,25 +1474,25 @@ packages:
 
 snapshots:
 
-  '@apollo/composition@2.13.2(graphql@16.13.1)':
+  '@apollo/composition@2.13.2(graphql@17.0.2)':
     dependencies:
-      '@apollo/federation-internals': 2.13.2(graphql@16.13.1)
-      '@apollo/query-graphs': 2.13.2(graphql@16.13.1)
-      graphql: 16.13.1
+      '@apollo/federation-internals': 2.13.2(graphql@17.0.2)
+      '@apollo/query-graphs': 2.13.2(graphql@17.0.2)
+      graphql: 17.0.2
 
-  '@apollo/federation-internals@2.13.2(graphql@16.13.1)':
+  '@apollo/federation-internals@2.13.2(graphql@17.0.2)':
     dependencies:
       '@types/uuid': 9.0.8
       chalk: 4.1.2
-      graphql: 16.13.1
+      graphql: 17.0.2
       js-levenshtein: 1.1.6
       uuid: 9.0.1
 
-  '@apollo/query-graphs@2.13.2(graphql@16.13.1)':
+  '@apollo/query-graphs@2.13.2(graphql@17.0.2)':
     dependencies:
-      '@apollo/federation-internals': 2.13.2(graphql@16.13.1)
+      '@apollo/federation-internals': 2.13.2(graphql@17.0.2)
       deep-equal: 2.2.3
-      graphql: 16.13.1
+      graphql: 17.0.2
       ts-graphviz: 1.8.2
       uuid: 9.0.1
 
@@ -2176,7 +2176,7 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  graphql@16.13.1: {}
+  graphql@17.0.2: {}
 
   has-bigints@1.1.0: {}
 

--- a/src/graphql/supergraph-spec.ts
+++ b/src/graphql/supergraph-spec.ts
@@ -16,8 +16,13 @@ import { sdl as policySdl } from "../specifications/policy.js";
 import { sdl as requiresSdl } from "../specifications/requires-scopes.js";
 import { sdl as tagSdl } from "../specifications/tag.js";
 
+type SupergraphSpecNodes = readonly {
+  name: string;
+  kind: Kind;
+}[];
+
 // For the sake of optimization, we cache the supergraph spec nodes and only compute them when needed.
-let supergraphSpecNodes: readonly { name: string; kind: Kind }[] | null = null;
+let supergraphSpecNodes: SupergraphSpecNodes;
 
 /**
  * Names of inputs, enums and scalars that are part of the supergraph spec,
@@ -38,11 +43,8 @@ export const extraFederationDirectiveNames = new Set([
   "context", // from Federation v2.8 - we don't support it yet
 ]);
 
-export function getSupergraphSpecNodes(): readonly {
-  name: string;
-  kind: Kind;
-}[] {
-  if (supergraphSpecNodes !== null) {
+export function getSupergraphSpecNodes(): SupergraphSpecNodes {
+  if (supergraphSpecNodes !== undefined) {
     return supergraphSpecNodes;
   }
 
@@ -69,7 +71,7 @@ export function getSupergraphSpecNodes(): readonly {
           kind: d.kind,
         })),
     )
-    .flat();
+    .flat() as SupergraphSpecNodes;
 
   return supergraphSpecNodes;
 }

--- a/src/subgraph/validation/rules/provided-required-arguments-on-directives-rule.ts
+++ b/src/subgraph/validation/rules/provided-required-arguments-on-directives-rule.ts
@@ -3,6 +3,7 @@ import {
   GraphQLError,
   InputValueDefinitionNode,
   Kind,
+  versionInfo,
 } from "graphql";
 import { print } from "../../../graphql/printer.js";
 import type { SimpleValidationContext } from "../validation-context.js";
@@ -41,16 +42,17 @@ export function ProvidedRequiredArgumentsOnDirectivesRule(
           for (const [argName, argDef] of Object.entries(requiredArgs)) {
             if (!argNodeMap.has(argName)) {
               const argType = print(argDef.type);
+              const message =
+                versionInfo.major < 17
+                  ? `Directive "@${directiveName}" argument "${argName}" of type "${argType}" is required, but it was not provided.`
+                  : `Argument "@${directiveName}(${argName}:)" of type "${argType}" is required, but it was not provided.`;
               context.reportError(
-                new GraphQLError(
-                  `Argument "@${directiveName}(${argName}:)" of type "${argType}" is required, but it was not provided.`,
-                  {
-                    nodes: directiveNode,
-                    extensions: {
-                      code: "INVALID_GRAPHQL",
-                    },
+                new GraphQLError(message, {
+                  nodes: directiveNode,
+                  extensions: {
+                    code: "INVALID_GRAPHQL",
                   },
-                ),
+                }),
               );
             }
           }

--- a/src/subgraph/validation/rules/provided-required-arguments-on-directives-rule.ts
+++ b/src/subgraph/validation/rules/provided-required-arguments-on-directives-rule.ts
@@ -43,7 +43,7 @@ export function ProvidedRequiredArgumentsOnDirectivesRule(
               const argType = print(argDef.type);
               context.reportError(
                 new GraphQLError(
-                  `Directive "@${directiveName}" argument "${argName}" of type "${argType}" is required, but it was not provided.`,
+                  `Argument "@${directiveName}(${argName}:)" of type "${argType}" is required, but it was not provided.`,
                   {
                     nodes: directiveNode,
                     extensions: {

--- a/src/subgraph/validation/validate-state.ts
+++ b/src/subgraph/validation/validate-state.ts
@@ -401,7 +401,19 @@ function isValidateDefaultValue(
     )!;
 
     try {
-      specifiedScalar.parseLiteral(value);
+      // graphql-js 17 keeps legacy coercion in parseLiteral; its strict replacement
+      // is unavailable in graphql-js 16, which we continue to support.
+      const coerceInputLiteral = (
+        specifiedScalar as unknown as {
+          coerceInputLiteral?: (value: ValueNode) => unknown;
+        }
+      ).coerceInputLiteral;
+
+      if (coerceInputLiteral) {
+        coerceInputLiteral.call(specifiedScalar, value);
+      } else {
+        specifiedScalar.parseLiteral(value, undefined);
+      }
       return true;
     } catch (error) {
       return false;

--- a/src/subgraph/validation/validate-state.ts
+++ b/src/subgraph/validation/validate-state.ts
@@ -1,10 +1,12 @@
 import {
+  ConstValueNode,
   GraphQLError,
   introspectionTypes,
   Kind,
   parseValue,
   specifiedScalarTypes,
   ValueNode,
+  versionInfo,
 } from "graphql";
 import { andList } from "../../utils/format.js";
 import {
@@ -403,16 +405,13 @@ function isValidateDefaultValue(
     try {
       // graphql-js 17 keeps legacy coercion in parseLiteral; its strict replacement
       // is unavailable in graphql-js 16, which we continue to support.
-      const coerceInputLiteral = (
-        specifiedScalar as unknown as {
-          coerceInputLiteral?: (value: ValueNode) => unknown;
-        }
-      ).coerceInputLiteral;
-
-      if (coerceInputLiteral) {
-        coerceInputLiteral.call(specifiedScalar, value);
-      } else {
+      if (versionInfo.major < 17) {
         specifiedScalar.parseLiteral(value, undefined);
+      } else {
+        if (value.kind === Kind.VARIABLE) {
+          return false;
+        }
+        specifiedScalar.coerceInputLiteral?.(value as ConstValueNode);
       }
       return true;
     } catch (error) {


### PR DESCRIPTION
This adds support for graphql-js 17.

I attempted to introduce everything in a backwards compatible way by leveraging the `versionInfo` exported from graphql-js.