### PR TITLE
fix: prevent context field scalar leaking into supergraph

### DIFF
--- a/.changeset/clean-context-field-value.md
+++ b/.changeset/clean-context-field-value.md
@@ -1,0 +1,5 @@
+---
+"@theguild/federation-composition": patch
+---
+
+Prevent `federation__ContextFieldValue` declared in a subgraph's `_service.sdl` from leaking into the supergraph.

--- a/__tests__/context.spec.ts
+++ b/__tests__/context.spec.ts
@@ -1454,6 +1454,30 @@ testVersions((api, version) => {
     });
   });
   describe("supergraph", () => {
+    test("does not leak federation__ContextFieldValue from service SDL", () => {
+      const result = compose([
+        subgraph(
+          "accounts",
+          graphql`
+              scalar federation__ContextFieldValue
+
+              type Query {
+                account: Account
+              }
+
+              type Account @context(name: "accountCtx") {
+                locale: String!
+              }
+            `,
+        ),
+      ]);
+
+      assertCompositionSuccess(result);
+      expect(result.supergraphSdl).not.toContain(
+        "scalar federation__ContextFieldValue",
+      );
+    });
+
     const materializedContextCases = [
       {
         title: "writes a nested scalar selection to the join metadata",

--- a/src/subgraph/state.ts
+++ b/src/subgraph/state.ts
@@ -1276,6 +1276,7 @@ export function cleanSubgraphStateFromFederationSpec(
   state.types.delete("federation__FieldSet");
   state.types.delete("federation__Policy");
   state.types.delete("federation__Scope");
+  state.types.delete("federation__ContextFieldValue");
 
   return state;
 }


### PR DESCRIPTION
## Summary

- remove `federation__ContextFieldValue` from subgraph state with the other Federation built-in scalars
- add a regression test for `_service.sdl` that declares the context field scalar
- add a patch changeset

Without the cleanup, the composed supergraph assigns the built-in scalar to a subgraph. Apollo Router / `@apollo/federation-internals` then rejects extraction with:

```text
Type federation__ContextFieldValue already exists in this schema
```

The regression reproduces on Federation v2.8 and v2.9 before the fix.

Follow-up to #326. This is a focused version of the scalar-leak fix identified in Uri Goldshtein's unmerged `test/service-sdl-context-directives` branch (`457c0e8`). Uri is credited as co-author.

## Validation

- `pnpm typecheck`
- `pnpm test --run --reporter=dot` (7,201 passed, 25 skipped, 8 todo)
- focused context test: 292 passed