### PR TITLE
fix: preserve type referenced by directive arguments when removing unreachable types from schema contracts

### DIFF
--- a/.changeset/bright-directives-reach.md
+++ b/.changeset/bright-directives-reach.md
@@ -1,0 +1,5 @@
+---
+"@theguild/federation-composition": patch
+---
+
+Preserve types referenced by directive arguments when removing unreachable types from schema contracts.

--- a/__tests__/contracts/compose-schema-contract.spec.ts
+++ b/__tests__/contracts/compose-schema-contract.spec.ts
@@ -99,6 +99,53 @@ describe("composeSchemaContract", () => {
     `);
   });
 
+  test("keeps types referenced by composed directives when removing unreachable types", () => {
+    const result = composeSchemaContract(
+      [
+        {
+          name: "products",
+          url: "https://products.example.com/graphql",
+          typeDefs: parse(/* GraphQL */ `
+            extend schema
+              @link(
+                url: "https://specs.apollo.dev/federation/v2.5"
+                import: ["@key", "@tag", "@composeDirective"]
+              )
+              @link(url: "https://myspecs.dev/meta/v1.0", import: ["@meta"])
+              @composeDirective(name: "@meta")
+
+            directive @meta(options: MetaOptions) repeatable on FIELD_DEFINITION
+
+            scalar MetaOptions
+
+            type Product @key(fields: "id") {
+              id: ID!
+              name: String @meta(options: {}) @tag(name: "internal")
+              secret: String @tag(name: "internal")
+            }
+
+            type Query {
+              product: Product
+            }
+          `),
+        },
+      ],
+      {
+        include: new Set(),
+        exclude: new Set(["internal"]),
+      },
+      true,
+    );
+
+    expect(result.errors).toEqual(undefined);
+    expect((result as CompositionSuccess).publicSdl).toContain(
+      "directive @meta(options: MetaOptions) repeatable on FIELD_DEFINITION",
+    );
+    expect((result as CompositionSuccess).publicSdl).toContain(
+      "scalar MetaOptions",
+    );
+  });
+
   test("contract: mutation type is not part of the public schema if all fields are excluded", () => {
     const sdl = /* GraphQL */ `
       schema

--- a/__tests__/contracts/reachable-type-filter.spec.ts
+++ b/__tests__/contracts/reachable-type-filter.spec.ts
@@ -161,6 +161,24 @@ describe("getReachableTypes", () => {
     expect(reachableTypes.has("Hello")).toEqual(true);
     expect(reachableTypes.has("World")).toEqual(true);
   });
+  test("includes types referenced by directive arguments", () => {
+    const documentNode = parse(/* GraphQL */ `
+      directive @meta(options: MetaOptions) on FIELD_DEFINITION
+      input MetaOptions {
+        visibility: Visibility
+      }
+      enum Visibility {
+        PUBLIC
+        PRIVATE
+      }
+      type Query {
+        hello: String
+      }
+    `);
+    const reachableTypes = getReachableTypes(documentNode);
+    expect(reachableTypes.has("MetaOptions")).toEqual(true);
+    expect(reachableTypes.has("Visibility")).toEqual(true);
+  });
 });
 
 describe("addDirectiveOnTypes", () => {

--- a/src/contracts/reachable-type-filter.ts
+++ b/src/contracts/reachable-type-filter.ts
@@ -6,6 +6,7 @@ import {
   isInterfaceType,
   isObjectType,
   isScalarType,
+  isSpecifiedDirective,
   isUnionType,
   Kind,
   specifiedScalarTypes,
@@ -48,6 +49,10 @@ export function getReachableTypes(documentNode: DocumentNode): Set<string> {
   }
 
   for (const directive of schema.getDirectives()) {
+    if (isSpecifiedDirective(directive)) {
+      continue;
+    }
+
     for (const arg of directive.args) {
       processNamedType(getNamedType(arg.type));
     }

--- a/src/contracts/reachable-type-filter.ts
+++ b/src/contracts/reachable-type-filter.ts
@@ -47,6 +47,12 @@ export function getReachableTypes(documentNode: DocumentNode): Set<string> {
     processNamedType(subscriptionType);
   }
 
+  for (const directive of schema.getDirectives()) {
+    for (const arg of directive.args) {
+      processNamedType(getNamedType(arg.type));
+    }
+  }
+
   function processNamedType(tType: GraphQLNamedType) {
     if (didVisitType.has(tType) || specifiedScalarNames.has(tType.name)) {
       return;


### PR DESCRIPTION
Preserve type referenced by directive arguments when removing unreachable types from schema contracts

We did not traverse the directive definitions before.

Closes #330