### PR TITLE
Accessible directive args

### DIFF
--- a/.changeset/social-camels-pay.md
+++ b/.changeset/social-camels-pay.md
@@ -1,0 +1,5 @@
+---
+"@theguild/federation-composition": patch
+---
+
+Do not mark directive arguments as unused in addInaccessibleToUnreachableTypes

--- a/__tests__/contracts/add-inaccessible-to-unreachable-types.spec.ts
+++ b/__tests__/contracts/add-inaccessible-to-unreachable-types.spec.ts
@@ -113,6 +113,53 @@ test("Filters based on tags", async () => {
   `);
 });
 
+test("Inaccessible is not added to a custom directive (or its custom scalar argument) included via @composeDirective", async () => {
+  let compositionResult = composeServices([
+    {
+      name: "user",
+      url: "https://user-example.graphql-hive.com",
+      typeDefs: parse(`
+        extend schema
+          @link(url: "https://specs.apollo.dev/federation/v2.9", import: ["@composeDirective"])
+          @link(url: "https://myspecs.dev/custom/v1.0", import: ["@custom"])
+          @composeDirective(name: "@custom")
+
+        scalar CustomScalar
+
+        directive @custom(arg: CustomScalar) on FIELD_DEFINITION
+
+        type Query {
+          user: User
+        }
+        type User {
+          id: ID!
+          name: String @custom(arg: "foo")
+        }
+      `),
+    },
+  ]);
+
+  expect(compositionResult.errors).toBe(undefined);
+  expect(compositionResult.supergraphSdl).not.toBe(undefined);
+  const { resolveImportName } = extractLinkImplementations(
+    parse(compositionResult.supergraphSdl!),
+  );
+
+  compositionResult = addInaccessibleToUnreachableTypes(
+    resolveImportName,
+    compositionResult as CompositionSuccess,
+  );
+  expect(compositionResult.supergraphSdl).to.include(
+    "directive @custom(arg: CustomScalar) on FIELD_DEFINITION",
+  );
+  expect(compositionResult.supergraphSdl).to.include(
+    "scalar CustomScalar @join__type(graph: USER)",
+  );
+  expect(compositionResult.supergraphSdl).to.not.include(
+    "scalar CustomScalar @join__type(graph: USER) @inaccessible",
+  );
+});
+
 test("Inaccessible is not added on built-in Federation types ContextArgument and FieldValue", async () => {
   const sdl = /* GraphQL */ `
     extend schema

--- a/src/contracts/reachable-type-filter.ts
+++ b/src/contracts/reachable-type-filter.ts
@@ -6,6 +6,7 @@ import {
   isInterfaceType,
   isObjectType,
   isScalarType,
+  isSpecifiedDirective,
   isUnionType,
   Kind,
   specifiedScalarTypes,
@@ -14,6 +15,7 @@ import {
   type DocumentNode,
   type EnumTypeDefinitionNode,
   type GraphQLNamedType,
+  type GraphQLSchema,
   type GraphQLType,
   type InputObjectTypeDefinitionNode,
   type InterfaceTypeDefinitionNode,
@@ -24,28 +26,13 @@ import {
 
 const specifiedScalarNames = new Set(specifiedScalarTypes.map((t) => t.name));
 
-/**
- * Retrieve a named list of all types that are reachable from the root types.
- */
-export function getReachableTypes(documentNode: DocumentNode): Set<string> {
+function walkReachableTypes(
+  schema: GraphQLSchema,
+  types: Iterable<GraphQLNamedType>,
+): Set<string> {
   const reachableTypeNames = new Set<string>();
-  const schema = buildASTSchema(documentNode);
   const didVisitType = new Set<GraphQLType>();
   const typeQueue: Array<GraphQLNamedType> = [];
-
-  const queryType = schema.getQueryType();
-  const mutationType = schema.getMutationType();
-  const subscriptionType = schema.getSubscriptionType();
-
-  if (queryType) {
-    processNamedType(queryType);
-  }
-  if (mutationType) {
-    processNamedType(mutationType);
-  }
-  if (subscriptionType) {
-    processNamedType(subscriptionType);
-  }
 
   function processNamedType(tType: GraphQLNamedType) {
     if (didVisitType.has(tType) || specifiedScalarNames.has(tType.name)) {
@@ -54,6 +41,10 @@ export function getReachableTypes(documentNode: DocumentNode): Set<string> {
     didVisitType.add(tType);
     typeQueue.push(tType);
     reachableTypeNames.add(tType.name);
+  }
+
+  for (const type of types) {
+    processNamedType(type);
   }
 
   let currentType: GraphQLNamedType | undefined;
@@ -90,6 +81,31 @@ export function getReachableTypes(documentNode: DocumentNode): Set<string> {
   }
 
   return reachableTypeNames;
+}
+
+/**
+ * Retrieve a named list of all types that are reachable from the root types.
+ */
+export function getReachableTypes(documentNode: DocumentNode): Set<string> {
+  const schema = buildASTSchema(documentNode);
+
+  const rootTypes = [
+    schema.getQueryType(),
+    schema.getMutationType(),
+    schema.getSubscriptionType(),
+  ].filter((type): type is NonNullable<typeof type> => !!type);
+
+  const directiveArgumentTypes: GraphQLNamedType[] = [];
+  for (const directive of schema.getDirectives()) {
+    if (isSpecifiedDirective(directive)) {
+      continue;
+    }
+    for (const arg of directive.args) {
+      directiveArgumentTypes.push(getNamedType(arg.type));
+    }
+  }
+
+  return walkReachableTypes(schema, [...rootTypes, ...directiveArgumentTypes]);
 }
 
 /**


### PR DESCRIPTION
Currently, an invalid schema can be produced because a composed directive's arguments are flagged as `@inaccessible`

This change takes directive arguments into account so that the schema produced is valid.

Closes #329