### PR TITLE
fix: `ContectFieldValue` being marked as inaccessible

### DIFF
--- a/.changeset/lucky-bikes-jam.md
+++ b/.changeset/lucky-bikes-jam.md
@@ -1,0 +1,5 @@
+---
+"@theguild/federation-composition": patch
+---
+
+Fix scalar `ContextFieldValue` being annotated with `@inaccessible` within the supergraph when composing a contract schema.

--- a/__tests__/contracts/add-inaccessible-to-unreachable-types.spec.ts
+++ b/__tests__/contracts/add-inaccessible-to-unreachable-types.spec.ts
@@ -113,17 +113,21 @@ test("Filters based on tags", async () => {
   `);
 });
 
-test("Inaccessible is not added on built-in Federation types ContextArgument and FieldValue", async () => {
+test("Inaccessible is not added on built-in Federation and context types", async () => {
   const sdl = /* GraphQL */ `
     extend schema
-      @link(url: "https://specs.apollo.dev/federation/v2.9", import: ["@key"])
+      @link(
+        url: "https://specs.apollo.dev/federation/v2.9"
+        import: ["@context", "@fromContext", "@key"]
+      )
 
     type Query {
       me: Me
     }
 
-    type Me @key(fields: "id") {
+    type Me @key(fields: "id") @context(name: "me") {
       id: ID!
+      contextualField(value: ID @fromContext(field: "$me { id }")): String
     }
   `;
 
@@ -157,5 +161,11 @@ test("Inaccessible is not added on built-in Federation types ContextArgument and
   );
   expect(compositionResult.supergraphSdl).to.include(
     "input join__ContextArgument {\n",
+  );
+  expect(compositionResult.supergraphSdl).to.include(
+    "scalar context__ContextFieldValue\n",
+  );
+  expect(compositionResult.supergraphSdl).to.not.include(
+    "scalar context__ContextFieldValue @inaccessible",
   );
 });

--- a/src/contracts/add-inaccessible-to-unreachable-types.ts
+++ b/src/contracts/add-inaccessible-to-unreachable-types.ts
@@ -1,4 +1,3 @@
-import { DocumentNode } from "graphql";
 import {
   CompositionSuccess,
   createCompositionSuccessReadCacheContainer,
@@ -37,6 +36,7 @@ export const addInaccessibleToUnreachableTypes = (
     resolveName("https://specs.apollo.dev/join", "DirectiveArguments"),
     resolveName("https://specs.apollo.dev/join", "ContextArgument"),
     resolveName("https://specs.apollo.dev/join", "FieldValue"),
+    resolveName("https://specs.apollo.dev/context", "ContextFieldValue"),
   ]);
 
   // we retrieve the list of reachable types from the public api sdl


### PR DESCRIPTION
Fix scalar `ContextFieldValue` being annotated with `@inaccessible` within the supergraph when composing a contract schema.